### PR TITLE
feat(US-06-01): 添加兴趣标签折叠展开

### DIFF
--- a/app/routes/activity.py
+++ b/app/routes/activity.py
@@ -8,9 +8,61 @@ activity_bp = Blueprint("activity", __name__)
 @activity_bp.route("/")
 def index():
     selected_tag = request.args.get("tag", "").strip()
-    categories = sorted({activity["category"] for activity in activities})
+    interest_tags = [
+        "胶片摄影",
+        "复古相机",
+        "城市骑行",
+        "公路车",
+        "手冲咖啡",
+        "独立出版",
+        "桌游",
+        "剧本围读",
+        "观影交流",
+        "摄影展",
+        "城市漫步",
+        "徒步",
+        "露营",
+        "飞盘",
+        "羽毛球",
+        "攀岩",
+        "滑板",
+        "夜跑",
+        "音乐现场",
+        "黑胶唱片",
+        "旧物市集",
+        "古着穿搭",
+        "二手书交换",
+        "书店探访",
+        "博物馆看展",
+        "手作体验",
+        "陶艺",
+        "插画手账",
+        "手帐拼贴",
+        "植物养护",
+        "宠物社交",
+        "烘焙",
+        "茶饮品鉴",
+        "香薰调香",
+        "语言角",
+        "开源技术",
+        "独立游戏",
+        "模型手办",
+        "汉服体验",
+        "天文观星",
+        "即兴戏剧",
+        "瑜伽冥想",
+        "本地美食",
+        "桌面摄影",
+        "咖啡拉花",
+        "街头摄影",
+        "骑行路线",
+        "周末约伴",
+        "轻户外",
+    ]
+    categories = interest_tags
+    visible_tag_count = 18
 
-    if selected_tag and selected_tag in categories:
+    if selected_tag and selected_tag in interest_tags:
         filtered_activities = [
             activity for activity in activities if activity["category"] == selected_tag
         ]
@@ -18,11 +70,19 @@ def index():
         filtered_activities = activities
         selected_tag = ""
 
+    expand_tags_by_default = (
+        bool(selected_tag)
+        and interest_tags.index(selected_tag) >= visible_tag_count
+    )
+
     return render_template(
         "index.html",
         activities=filtered_activities,
         categories=categories,
+        expand_tags_by_default=expand_tags_by_default,
+        interest_tags=interest_tags,
         selected_tag=selected_tag,
+        visible_tag_count=visible_tag_count,
     )
 
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -474,67 +474,115 @@ img {
   border-color: var(--color-primary);
 }
 
-/* 兴趣标签 chip */
-.tag-chips {
-  display: flex;
-  gap: 10px;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin-top: 20px;
-}
-
-.tag-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 16px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 20px;
-  font-size: 14px;
-  color: var(--color-muted);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  user-select: none;
-}
-
-.tag-chip:hover {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
-}
-
-.tag-chip.active,
-.tag-chip.is-active {
-  background: var(--color-primary);
-  color: #ffffff;
-  border-color: var(--color-primary-dark);
-  font-weight: 700;
-  box-shadow: 0 2px 8px rgba(47, 111, 99, 0.22);
-}
-
-.tag-filter {
+.interest-section {
   margin: 0 0 28px;
-  padding: 18px;
+  padding: 24px;
   border: 1px solid var(--color-border);
   border-radius: 12px;
   background: var(--color-surface);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
-.tag-filter-list {
+.interest-header {
+  margin-bottom: 18px;
+}
+
+.interest-header .eyebrow {
+  margin-bottom: 6px;
+}
+
+.interest-title {
+  margin: 0 0 6px;
+  color: var(--color-text);
+  font-size: 24px;
+  line-height: 1.3;
+}
+
+.interest-subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 15px;
+}
+
+.interest-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  min-width: 0;
+}
+
+.interest-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  padding: 7px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: #fbfaf7;
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.interest-chip:hover {
+  border-color: var(--color-primary);
+  background: #e8f0ed;
+  color: var(--color-primary-dark);
+}
+
+.interest-chip.is-active {
+  border-color: var(--color-primary-dark);
+  background: var(--color-primary);
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.interest-chip.is-extra-tag {
+  display: none;
+}
+
+.interest-section.is-expanded .interest-chip.is-extra-tag {
+  display: inline-flex;
+}
+
+.interest-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  margin-top: 14px;
+  padding: 0 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: #fbfaf7;
+  color: var(--color-primary-dark);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.interest-toggle:hover {
+  border-color: var(--color-primary);
+  background: #e8f0ed;
+  color: var(--color-primary);
 }
 
 .filter-status {
-  margin: 14px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  margin: 16px 0 0;
   color: var(--color-muted);
   font-size: 14px;
   font-weight: 600;
 }
 
 .filter-status a {
-  margin-left: 8px;
   color: var(--color-primary-dark);
   font-weight: 700;
 }
@@ -681,31 +729,30 @@ img {
 }
 
 @media (max-width: 720px) {
-  .tag-chips {
+  .interest-section {
+    padding: 16px;
+  }
+
+  .interest-title {
+    font-size: 20px;
+  }
+
+  .interest-tags {
     gap: 8px;
   }
 
-  .tag-filter {
-    padding: 14px;
-  }
-
-  .tag-filter-list {
-    gap: 8px;
-  }
-  
-  .tag-chip {
+  .interest-chip {
     padding: 6px 12px;
     font-size: 13px;
   }
 
-  .filter-status {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
+  .interest-toggle {
+    width: 100%;
   }
 
-  .filter-status a {
-    margin-left: 0;
+  .filter-status {
+    flex-direction: column;
+    gap: 6px;
   }
 
   .card-body {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -14,4 +14,18 @@ document.addEventListener("DOMContentLoaded", () => {
       });
     });
   }
+
+  const tagToggle = document.querySelector("[data-tag-toggle]");
+  if (tagToggle) {
+    tagToggle.addEventListener("click", () => {
+      const interestSection = tagToggle.closest(".interest-section");
+      if (!interestSection) {
+        return;
+      }
+
+      const isExpanded = interestSection.classList.toggle("is-expanded");
+      tagToggle.setAttribute("aria-expanded", String(isExpanded));
+      tagToggle.textContent = isExpanded ? "收起标签" : "展开更多兴趣";
+    });
+  }
 });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,14 +14,6 @@
             <button class="button">搜索</button>
         </div>
 
-        <!-- 兴趣标签 chip：US-06 标签筛选状态由后端同步 -->
-        <div class="tag-chips">
-            <a class="tag-chip {% if not selected_tag %}is-active{% endif %}" href="{{ url_for('activity.index') }}" data-tag="all">全部活动</a>
-            {% for category in categories %}
-            <a class="tag-chip {% if selected_tag == category %}is-active{% endif %}" href="{{ url_for('activity.index', tag=category) }}" data-tag="{{ category }}">{{ category }}</a>
-            {% endfor %}
-        </div>
-
         <div class="hero-actions">
             <a class="button" href="{{ url_for('activity.create_activity') }}">发布活动</a>
             <a class="button button-secondary" href="{{ url_for('circle.circles') }}">浏览同好圈</a>
@@ -36,20 +28,42 @@
             <h2>近期推荐活动</h2>
         </div>
 
-        <div class="tag-filter" aria-label="活动分类筛选">
-            <div class="tag-filter-list">
-                <a class="tag-chip {% if not selected_tag %}is-active{% endif %}" href="{{ url_for('activity.index') }}">全部活动</a>
-                {% for category in categories %}
-                <a class="tag-chip {% if selected_tag == category %}is-active{% endif %}" href="{{ url_for('activity.index', tag=category) }}">{{ category }}</a>
-                {% endfor %}
+        <section class="interest-section {% if expand_tags_by_default %}is-expanded{% endif %}" aria-labelledby="interest-title">
+            <div class="interest-header">
+                <p class="eyebrow">Interest Tags</p>
+                <h2 class="interest-title" id="interest-title">发现兴趣</h2>
+                <p class="interest-subtitle">从小众兴趣开始，找到附近适合你的线下活动。</p>
             </div>
-            {% if selected_tag %}
-            <p class="filter-status">
-                当前正在浏览：{{ selected_tag }}
-                <a href="{{ url_for('activity.index') }}">查看全部活动 / 清除筛选</a>
-            </p>
+
+            <div class="interest-tags">
+                <a class="interest-chip {% if not selected_tag %}is-active{% endif %}" href="{{ url_for('activity.index') }}">全部活动</a>
+                {% if interest_tags %}
+                {% for tag in interest_tags %}
+                <a class="interest-chip {% if loop.index > visible_tag_count %}is-extra-tag{% endif %} {% if selected_tag == tag %}is-active{% endif %}" href="{{ url_for('activity.index', tag=tag) }}">{{ tag }}</a>
+                {% endfor %}
+                {% else %}
+                <span class="interest-subtitle">暂无兴趣标签</span>
+                {% endif %}
+            </div>
+
+            {% if interest_tags|length > visible_tag_count %}
+            <button type="button"
+                    class="interest-toggle"
+                    data-tag-toggle
+                    aria-expanded="{{ 'true' if expand_tags_by_default else 'false' }}">
+                {{ '收起标签' if expand_tags_by_default else '展开更多兴趣' }}
+            </button>
             {% endif %}
-        </div>
+
+            <div class="filter-status">
+                {% if selected_tag %}
+                <span>当前正在浏览：{{ selected_tag }}</span>
+                <a href="{{ url_for('activity.index') }}">查看全部活动 / 清除筛选</a>
+                {% else %}
+                <span>当前正在浏览：全部活动</span>
+                {% endif %}
+            </div>
+        </section>
 
         {% if activities %}
         <div class="card-grid">


### PR DESCRIPTION
## 关联 Issue
Closes #60

## 本次完成内容
- 在首页添加统一的兴趣标签展示区域
- 添加丰富的小众兴趣标签内容
- 保留“全部活动”和当前选中标签高亮状态
- 增加兴趣标签折叠 / 展开功能
- 默认只显示部分标签，点击“展开更多兴趣”后显示全部
- 移动端下标签和按钮可以自动换行

## 自测情况
- [x] 本地可以正常运行
- [x] 首页能够显示兴趣标签列表
- [x] 默认状态下不会一次性展开全部标签
- [x] 点击“展开更多兴趣”后可以显示全部标签
- [x] 点击“收起标签”后可以恢复折叠
- [x] “全部活动”默认高亮
- [x] 点击具体标签后当前标签高亮
- [x] 移动端和桌面端显示正常
- [x] 没有修改 models.py、auth.py、circle.py、base.html、requirements.txt、run.py
- [x] 没有 Git 冲突标记

## 主要修改文件
- app/routes/activity.py
- app/templates/index.html
- app/static/css/style.css
- app/static/js/main.js

## 需要 Review 的重点
请检查兴趣标签展示数量、折叠展开交互、当前选中标签高亮状态，以及是否方便后续 US-06-02 标签筛选功能衔接。