### PR TITLE
feat(US-07-01): 优化同好圈列表展示

### DIFF
--- a/app/routes/circle.py
+++ b/app/routes/circle.py
@@ -1,74 +1,71 @@
 from flask import Blueprint, render_template
 
-from app.models import circles
-
 circle_bp = Blueprint("circle", __name__)
+
+mock_circles = [
+    {
+        "id": 1,
+        "name": "胶片摄影",
+        "tag": "影像",
+        "description": "用胶片捕捉光影，分享暗房技巧与器材心得，一起慢下来感受摄影的本质。",
+        "members": 342,
+        "activity_count": 8,
+    },
+    {
+        "id": 2,
+        "name": "城市骑行",
+        "tag": "户外",
+        "description": "周末城市探索骑行，从老城区到滨江绿道，用车轮丈量城市的温度。",
+        "members": 567,
+        "activity_count": 12,
+    },
+    {
+        "id": 3,
+        "name": "手冲咖啡",
+        "tag": "生活方式",
+        "description": "从选豆到注水，探索手冲咖啡的无限可能，定期举办杯测与分享会。",
+        "members": 218,
+        "activity_count": 6,
+    },
+    {
+        "id": 4,
+        "name": "独立出版",
+        "tag": "创作",
+        "description": "关注独立杂志、艺术书与 Zine 文化，为小众创作者提供交流与展示的平台。",
+        "members": 156,
+        "activity_count": 4,
+    },
+    {
+        "id": 5,
+        "name": "桌游",
+        "tag": "游戏",
+        "description": "从德式策略到美式主题，每周线下组局，欢迎新手和老玩家一起上桌。",
+        "members": 723,
+        "activity_count": 15,
+    },
+    {
+        "id": 6,
+        "name": "徒步",
+        "tag": "自然",
+        "description": "周末山野徒步，逃离城市喧嚣，用脚步发现身边的自然之美。",
+        "members": 489,
+        "activity_count": 10,
+    },
+]
 
 
 @circle_bp.route("/circles")
 def circles():
     """
-    同好圈页面路由。
-    TODO: TASK-005 同好圈负责人完善圈子列表、圈子详情和帖子功能。
+    用户浏览兴趣圈子列表页面路由。
+    US-07-01: 展示模拟兴趣圈子数据。
     """
-    return render_template("circle.html", circles=circles)
+    return render_template("circle.html", circles=mock_circles)
 
 
 @circle_bp.route("/circle")
 def circle_list():
     """
-    用户浏览兴趣圈子列表页面路由。
-    US-07-01: 展示模拟兴趣圈子数据，包含圈子名称、简介、本月活动数和成员数。
+    兼容旧的同好圈入口。
     """
-    mock_circles = [
-        {
-            "id": 1,
-            "name": "胶片摄影",
-            "description": "用胶片捕捉光影，分享暗房技巧与器材心得，一起慢下来感受摄影的本质。",
-            "activity_count": 8,
-            "member_count": 342,
-        },
-        {
-            "id": 2,
-            "name": "城市骑行",
-            "description": "周末城市探索骑行，从老城区到滨江绿道，用车轮丈量城市的温度。",
-            "activity_count": 12,
-            "member_count": 567,
-        },
-        {
-            "id": 3,
-            "name": "手冲咖啡",
-            "description": "从选豆到注水，探索手冲咖啡的无限可能，定期举办杯测与分享会。",
-            "activity_count": 6,
-            "member_count": 218,
-        },
-        {
-            "id": 4,
-            "name": "独立出版",
-            "description": "关注独立杂志、艺术书与Zine文化，为小众创作者提供交流与展示的平台。",
-            "activity_count": 4,
-            "member_count": 156,
-        },
-        {
-            "id": 5,
-            "name": "桌游",
-            "description": "从德式策略到美式主题，每周线下组局，欢迎新手和老玩家一起上桌。",
-            "activity_count": 15,
-            "member_count": 723,
-        },
-        {
-            "id": 6,
-            "name": "徒步",
-            "description": "周末山野徒步，逃离城市喧嚣，用脚步发现身边的自然之美。",
-            "activity_count": 10,
-            "member_count": 489,
-        },
-        {
-            "id": 7,
-            "name": "音乐现场",
-            "description": "聚焦本地Livehouse演出与独立音乐人，一起发现下一个打动你的声音。",
-            "activity_count": 9,
-            "member_count": 401,
-        },
-    ]
     return render_template("circle.html", circles=mock_circles)

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1056,3 +1056,37 @@ img {
     max-height: 240px;
   }
 }
+
+/* 同好圈列表页 US-07-01 */
+.circle-card {
+  min-width: 0;
+}
+
+.circle-card .card-body {
+  height: 100%;
+}
+
+.circle-description {
+  margin: 6px 0 0;
+  color: var(--color-muted);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.circle-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  margin-top: auto;
+  padding-top: 14px;
+}
+
+.circle-meta p {
+  margin: 0;
+}
+
+@media (max-width: 860px) {
+  .circle-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/templates/circle.html
+++ b/app/templates/circle.html
@@ -1,25 +1,37 @@
 {% extends "base.html" %}
 
-{% block title %}注册 - Gatherly{% endblock %}
+{% block title %}同好圈 - Gatherly{% endblock %}
 
 {% block content %}
-<section class="section narrow-page">
-    <p class="eyebrow">Register</p>
-    <h1>用户注册</h1>
+<section class="section">
+    <div class="container">
+        <div class="page-title">
+            <p class="eyebrow">Circles</p>
+            <h1>找到你的同好圈</h1>
+            <p>浏览不同兴趣社区，发现和你一样热爱小众活动的人。</p>
+        </div>
 
-    <!-- TODO: TASK-004 登录注册负责人完成注册表单 -->
-    <!-- 字段建议：
-        1. 昵称
-        2. 邮箱
-        3. 密码
-        4. 确认密码
-        5. 兴趣标签
-        6. 注册按钮
-        7. 跳转登录页
-    -->
-
-    <div class="placeholder-box">
-        注册表单待完成。
+        {% if circles %}
+        <div class="card-grid circle-grid">
+            {% for circle in circles %}
+            <article class="activity-card circle-card">
+                <div class="card-body">
+                    <span class="tag">{{ circle.tag }}</span>
+                    <h3 class="card-title">{{ circle.name }}</h3>
+                    <p class="circle-description">{{ circle.description }}</p>
+                    <div class="card-meta circle-meta">
+                        <p>{{ circle.members }} 位成员</p>
+                        <p>{{ circle.activity_count }} 场本月活动</p>
+                    </div>
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+        {% else %}
+        <div class="empty-state">
+            <p>暂时还没有同好圈，稍后再来看看。</p>
+        </div>
+        {% endif %}
     </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
对应 Issue：#38 [US-07-01] 用户浏览兴趣圈子列表

修改原因：
实现同好圈列表页，让用户可以浏览不同兴趣圈子。

修改内容：
1. 在 circle.py 中准备同好圈列表数据；
2. 在 circle.html 中使用卡片布局展示圈子名称、标签、简介、成员数和活跃信息；
3. 在 style.css 中补充同好圈卡片和移动端样式。

自测结果：
1. 本地运行 python run.py 正常；
2. 访问 /circles 页面正常；
3. 页面至少展示 4 个圈子；
4. 移动端宽度下卡片正常单列显示。

影响范围：
app/routes/circle.py
app/templates/circle.html
app/static/css/style.css