### PR TITLE
Feat/us 06 03 show all activities

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -84,4 +84,17 @@ document.addEventListener("DOMContentLoaded", () => {
       tagToggle.textContent = isExpanded ? "收起标签" : "展开更多兴趣";
     });
   }
+
+  // US-06-03: 清除筛选链接 — 无刷新跳转到全部
+  const clearFilterLink = document.querySelector(".clear-filter-link");
+  if (clearFilterLink) {
+    clearFilterLink.addEventListener("click", (e) => {
+      e.preventDefault();
+      // 点击"全部"标签，触发筛选切换
+      const allChip = document.querySelector('.interest-chip[data-tag="all"]');
+      if (allChip) {
+        allChip.click();
+      }
+    });
+  }
 });

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // 筛选活动卡片
         const cards = document.querySelectorAll(".activity-card");
-        if (selectedTag === "全部活动") {
+        if (selectedTag === "all") {
           cards.forEach(card => { card.style.display = ""; });
         } else {
           cards.forEach(card => {
@@ -32,7 +32,7 @@ document.addEventListener("DOMContentLoaded", () => {
         // 动态更新 filter-status 区域
         const filterStatus = document.querySelector(".filter-status");
         if (filterStatus) {
-          if (selectedTag === "全部活动") {
+          if (selectedTag === "all") {
             filterStatus.innerHTML = "当前正在浏览：全部活动";
           } else {
             const clearLink = document.createElement("a");
@@ -40,7 +40,7 @@ document.addEventListener("DOMContentLoaded", () => {
             clearLink.textContent = "查看全部活动 / 清除筛选";
             clearLink.addEventListener("click", (ev) => {
               ev.preventDefault();
-              const allChip = document.querySelector('.interest-chip[data-tag="全部活动"]');
+              const allChip = document.querySelector('.interest-chip[data-tag="all"]');
               if (allChip) allChip.click();
             });
             filterStatus.innerHTML = "";

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,7 +36,7 @@
             </div>
 
             <div class="interest-tags">
-                <a class="interest-chip {% if not selected_tag %}is-active{% endif %}" href="{{ url_for('activity.index') }}" data-tag="全部活动">全部活动</a>
+                <a class="interest-chip {% if not selected_tag %}is-active{% endif %}" href="{{ url_for('activity.index') }}" data-tag="all">全部活动</a>
                 {% if interest_tags %}
                 {% for tag in interest_tags %}
                 <a class="interest-chip {% if loop.index > visible_tag_count %}is-extra-tag{% endif %} {% if selected_tag == tag %}is-active{% endif %}" href="{{ url_for('activity.index', tag=tag) }}" data-tag="{{ tag }}">{{ tag }}</a>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -58,7 +58,7 @@
             <div class="filter-status">
                 {% if selected_tag %}
                 <span>当前正在浏览：{{ selected_tag }}</span>
-                <a href="{{ url_for('activity.index') }}">查看全部活动 / 清除筛选</a>
+                <a href="#" class="clear-filter-link">查看全部活动 / 清除筛选</a>
                 {% else %}
                 <span>当前正在浏览：全部活动</span>
                 {% endif %}


### PR DESCRIPTION

**对应Issue**：#36 [US-06-03] 用户恢复查看全部活动

**修改内容**：
1. `index.html` 第39行：将「全部」标签的 `data-tag` 属性从 `"全部活动"` 改为 `"all"`，确保语义统一
2. `index.html` 第61行：将清除筛选链接从 `href="{{ url_for('activity.index') }}"` 改为 `href="#" class="clear-filter-link"`，避免页面刷新
3. `main.js` 第21行：筛选条件从 `selectedTag === "全部活动"` 改为 `selectedTag === "all"`
4. `main.js` 第30行：filter-status 更新条件从 `selectedTag === "全部活动"` 改为 `selectedTag === "all"`
5. `main.js` 第33行：清除筛选链接中的 querySelector 选择器从 `data-tag="全部活动"` 改为 `data-tag="all"`
6. `main.js` 第86-97行：新增 `.clear-filter-link` 事件监听，点击时触发「全部」标签的 click 事件，实现无刷新清除筛选

**自测结果**：
- [x] 页面加载「全部」默认高亮
- [x] 点击「全部」正确恢复所有活动
- [x] 标签高亮状态切换正常
- [x] 完全兼容 US-06-02 标签筛选功能
- [x] 活动卡片功能不受影响
- [x] 清除筛选链接无页面刷新

**影响范围**：`app/templates/index.html`、`app/static/js/main.js`