### PR TITLE
feat(US-03-04): 活动详情页展示准备事项

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -35,6 +35,7 @@ class Activity(db.Model):
     status = db.Column(db.String(20), default="open", nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     organizer_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    preparation = db.Column(db.Text)  # 活动准备事项
 
     organizer = db.relationship("User", back_populates="activities")
     registrations = db.relationship("Registration", back_populates="activity")

--- a/app/routes/activity.py
+++ b/app/routes/activity.py
@@ -119,6 +119,7 @@ def activity_detail(activity_id):
         registration_count = Registration.query.filter_by(activity_id=activity_id).count()
         db_activity = Activity.query.get(activity_id)
         max_participants = db_activity.max_participants if db_activity else None
+        preparation = db_activity.preparation if db_activity else None
         user_registered = False
         if "user_id" in session:
             user_registered = Registration.query.filter_by(
@@ -127,6 +128,7 @@ def activity_detail(activity_id):
     except Exception:
         registration_count = 0
         max_participants = None
+        preparation = None
         user_registered = False
 
     return render_template(
@@ -134,6 +136,7 @@ def activity_detail(activity_id):
         activity=activity,
         registration_count=registration_count,
         max_participants=max_participants,
+        preparation=preparation,
         user_registered=user_registered,
     )
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1052,6 +1052,25 @@ img {
   white-space: pre-line;
 }
 
+/* 活动准备事项内容 */
+.preparation-content {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.8;
+  color: var(--color-text);
+  white-space: pre-line;  /* 保留换行符 */
+  word-wrap: break-word;
+}
+
+/* 空状态提示 */
+.preparation-empty {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.8;
+  color: var(--color-muted);
+  font-style: italic;
+}
+
 /* 移动端适配 */
 @media (max-width: 720px) {
   .detail-title {

--- a/app/templates/activity_detail.html
+++ b/app/templates/activity_detail.html
@@ -90,6 +90,16 @@
             <p>{{ activity.description or activity.detail }}</p>
         </div>
         {% endif %}
+
+        <!-- 活动准备事项 -->
+        <div class="detail-description">
+            <h3>活动准备事项</h3>
+            {% if preparation %}
+                <p class="preparation-content">{{ preparation }}</p>
+            {% else %}
+                <p class="preparation-empty">暂无活动准备事项</p>
+            {% endif %}
+        </div>
     </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
对应 Issue：#21 [US-03-04]
实现功能：
1. 活动详情页新增活动准备事项模块
2. 支持多行文本展示
3. 无内容时友好提示
4. 样式与页面统一美观

自测：本地运行正常 ✅