### PR TITLE
fix(US-09-02): 修复多维度评分校验与展示

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -91,6 +91,10 @@ class Review(db.Model):
 
 
 class Rating(db.Model):
+    __table_args__ = (
+        db.UniqueConstraint("activity_id", "user_id", name="uq_rating_activity_user"),
+    )
+
     id = db.Column(db.Integer, primary_key=True)
     activity_id = db.Column(db.Integer, db.ForeignKey("activity.id"), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)

--- a/app/routes/activity.py
+++ b/app/routes/activity.py
@@ -1,8 +1,10 @@
 from flask import Blueprint, abort, render_template, request, session, redirect, url_for, flash
 from functools import wraps
 from datetime import datetime
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 
-from app.models import db, Activity, Registration, activities
+from app.models import db, Activity, Registration, Rating, activities
 
 def login_required(f):
     """登录态检查装饰器，未登录重定向到登录页"""
@@ -16,6 +18,52 @@ def login_required(f):
 
 
 activity_bp = Blueprint("activity", __name__)
+
+
+RATING_ELIGIBLE_STATUSES = {"registered", "attended", "completed"}
+
+
+def _parse_rating_score(field_name):
+    raw_value = request.form.get(field_name)
+    if raw_value is None or raw_value == "":
+        raise ValueError("missing")
+
+    score = int(raw_value)
+    if score < 1 or score > 5:
+        raise ValueError("out_of_range")
+    return score
+
+
+def _get_rating_stats(activity_id):
+    stats = (
+        db.session.query(
+            func.count(Rating.id).label("rating_count"),
+            func.avg(Rating.organization_score).label("organization_avg"),
+            func.avg(Rating.venue_score).label("venue_avg"),
+            func.avg(Rating.experience_score).label("experience_avg"),
+            func.avg(Rating.average_score).label("overall_avg"),
+        )
+        .filter(Rating.activity_id == activity_id)
+        .one()
+    )
+
+    rating_count = int(stats.rating_count or 0)
+    if rating_count == 0:
+        return {
+            "count": 0,
+            "organization_avg": None,
+            "venue_avg": None,
+            "experience_avg": None,
+            "overall_avg": None,
+        }
+
+    return {
+        "count": rating_count,
+        "organization_avg": round(float(stats.organization_avg), 1),
+        "venue_avg": round(float(stats.venue_avg), 1),
+        "experience_avg": round(float(stats.experience_avg), 1),
+        "overall_avg": round(float(stats.overall_avg), 1),
+    }
 
 
 @activity_bp.route("/")
@@ -89,7 +137,6 @@ def index():
     )
 
     # 合并真实报名人数到硬编码活动数据
-    from sqlalchemy import func
     reg_counts = dict(
         db.session.query(Registration.activity_id, func.count(Registration.id))
         .group_by(Registration.activity_id)
@@ -115,30 +162,42 @@ def activity_detail(activity_id):
     if activity is None:
         abort(404)
 
-    try:
-        registration_count = Registration.query.filter_by(activity_id=activity_id).count()
-        db_activity = Activity.query.get(activity_id)
-        max_participants = db_activity.max_participants if db_activity else None
-        preparation = db_activity.preparation if db_activity else None
-        user_registered = False
-        has_rated = False
-        can_rate = False
-        if "user_id" in session:
-            user_registered = Registration.query.filter_by(
-                user_id=session["user_id"], activity_id=activity_id
-            ).first() is not None
-            has_rated = Rating.query.filter_by(
-                user_id=session["user_id"], activity_id=activity_id
-            ).first() is not None
-            if not has_rated and user_registered and db_activity and db_activity.start_time:
-                can_rate = db_activity.start_time < datetime.utcnow()
-    except Exception:
-        registration_count = 0
-        max_participants = None
-        preparation = None
-        user_registered = False
-        has_rated = False
-        can_rate = False
+    registration_count = Registration.query.filter_by(activity_id=activity_id).count()
+    db_activity = Activity.query.get(activity_id)
+    max_participants = db_activity.max_participants if db_activity else None
+    preparation = db_activity.preparation if db_activity else None
+    rating_stats = _get_rating_stats(activity_id)
+
+    user_registered = False
+    has_rated = False
+    can_rate = False
+    rating_notice = "登录并报名参加活动后，可在活动结束后评分。"
+
+    if "user_id" not in session:
+        rating_notice = "请先登录后再评分。"
+    else:
+        registration = Registration.query.filter_by(
+            user_id=session["user_id"], activity_id=activity_id
+        ).first()
+        user_registered = (
+            registration is not None
+            and registration.status in RATING_ELIGIBLE_STATUSES
+        )
+        has_rated = Rating.query.filter_by(
+            user_id=session["user_id"], activity_id=activity_id
+        ).first() is not None
+
+        if not user_registered:
+            rating_notice = "只有已报名并参加该活动的用户可以评分。"
+        elif has_rated:
+            rating_notice = "您已提交过评分，不能重复评分。"
+        elif not db_activity or not db_activity.start_time:
+            rating_notice = "活动时间未确认，暂不能评分。"
+        elif db_activity.start_time >= datetime.utcnow():
+            rating_notice = "活动尚未结束，暂不能评分。"
+        else:
+            can_rate = True
+            rating_notice = ""
 
     return render_template(
         "activity_detail.html",
@@ -149,6 +208,8 @@ def activity_detail(activity_id):
         user_registered=user_registered,
         has_rated=has_rated,
         can_rate=can_rate,
+        rating_notice=rating_notice,
+        rating_stats=rating_stats,
     )
 
 
@@ -222,39 +283,33 @@ def submit_rating(activity_id):
 
     user_id = session["user_id"]
 
-    # 重复评分检查
+    db_activity = Activity.query.get(activity_id)
+    if not db_activity or not db_activity.start_time:
+        flash("活动时间未确认，暂不能评分", "error")
+        return redirect(url_for("activity.activity_detail", activity_id=activity_id))
+
+    if db_activity.start_time >= datetime.utcnow():
+        flash("活动尚未结束，暂不能评分", "error")
+        return redirect(url_for("activity.activity_detail", activity_id=activity_id))
+
+    registered = Registration.query.filter_by(
+        user_id=user_id, activity_id=activity_id
+    ).first()
+    if not registered or registered.status not in RATING_ELIGIBLE_STATUSES:
+        flash("只有已报名并参加该活动的用户可以评分", "error")
+        return redirect(url_for("activity.activity_detail", activity_id=activity_id))
+
     existing = Rating.query.filter_by(user_id=user_id, activity_id=activity_id).first()
     if existing:
-        flash("您已对该活动评过分了", "error")
+        flash("您已提交过评分，不能重复评分", "error")
         return redirect(url_for("activity.activity_detail", activity_id=activity_id))
-
-    # 活动时间检查
-    db_activity = Activity.query.get(activity_id)
-    if db_activity and db_activity.start_time and db_activity.start_time >= datetime.utcnow():
-        flash("活动尚未开始，暂不能评分", "error")
-        return redirect(url_for("activity.activity_detail", activity_id=activity_id))
-
-    # 报名状态检查
-    registered = Registration.query.filter_by(user_id=user_id, activity_id=activity_id).first()
-    if not registered:
-        flash("您未报名该活动，无法评分", "error")
-        return redirect(url_for("activity.activity_detail", activity_id=activity_id))
-
-    # 获取三维度评分
-    org_score_raw = request.form.get("organization_score", 0)
-    venue_score_raw = request.form.get("venue_score", 0)
-    exp_score_raw = request.form.get("experience_score", 0)
 
     try:
-        org_score = int(org_score_raw)
-        venue_score = int(venue_score_raw)
-        exp_score = int(exp_score_raw)
+        org_score = _parse_rating_score("organization_score")
+        venue_score = _parse_rating_score("venue_score")
+        exp_score = _parse_rating_score("experience_score")
     except (TypeError, ValueError):
-        flash("评分值必须为数字", "error")
-        return redirect(url_for("activity.activity_detail", activity_id=activity_id))
-
-    if not (1 <= org_score <= 5 and 1 <= venue_score <= 5 and 1 <= exp_score <= 5):
-        flash("评分值必须在1-5之间", "error")
+        flash("每个评分必须是 1 到 5 的整数", "error")
         return redirect(url_for("activity.activity_detail", activity_id=activity_id))
 
     avg_score = round((org_score + venue_score + exp_score) / 3, 1)
@@ -271,7 +326,10 @@ def submit_rating(activity_id):
     try:
         db.session.add(rating)
         db.session.commit()
-        flash("评分提交成功，感谢您的反馈！", "success")
+        flash("评分提交成功，感谢您的反馈", "success")
+    except IntegrityError:
+        db.session.rollback()
+        flash("您已提交过评分，不能重复评分", "error")
     except Exception:
         db.session.rollback()
         flash("评分提交失败，请稍后重试", "error")

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1455,3 +1455,154 @@ textarea.form-input {
         padding-top: 20px;
     }
 }
+
+/* ============================================
+   活动多维度评分 (US-09-02)
+   ============================================ */
+
+.rating-section {
+  margin-top: 24px;
+  padding: 24px;
+  border-radius: 12px;
+  background: var(--color-surface);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.rating-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.rating-header h3 {
+  margin: 0;
+  color: var(--color-primary-dark);
+  font-size: 18px;
+}
+
+.rating-count,
+.rating-empty,
+.rating-notice {
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.rating-summary {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.rating-overall {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.rating-overall-label {
+  margin-right: 6px;
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.rating-overall strong {
+  color: var(--color-primary-dark);
+  font-size: 32px;
+  line-height: 1;
+}
+
+.rating-averages {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.rating-average-item {
+  padding: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: #fbfaf7;
+}
+
+.rating-average-item span {
+  display: block;
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.rating-average-item strong {
+  display: block;
+  margin-top: 4px;
+  color: var(--color-text);
+  font-size: 22px;
+  line-height: 1.1;
+}
+
+.rating-form {
+  display: grid;
+  gap: 16px;
+  padding-top: 18px;
+  border-top: 1px solid var(--color-border);
+}
+
+.rating-dimension h4 {
+  margin: 0 0 8px;
+  color: var(--color-text);
+  font-size: 15px;
+}
+
+.star-rating {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.star-rating input {
+  position: absolute;
+  opacity: 0;
+}
+
+.star-rating label {
+  padding: 0 3px;
+  color: #c9c3ba;
+  cursor: pointer;
+  font-size: 28px;
+  line-height: 1;
+}
+
+.star-rating input:checked ~ label,
+.star-rating label:hover,
+.star-rating label:hover ~ label {
+  color: #f5a623;
+}
+
+.rating-submit {
+  justify-self: start;
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+}
+
+.rating-notice,
+.rating-empty {
+  margin: 0;
+}
+
+@media (max-width: 720px) {
+  .rating-section {
+    padding: 16px;
+  }
+
+  .rating-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .rating-averages {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/templates/activity_detail.html
+++ b/app/templates/activity_detail.html
@@ -3,41 +3,7 @@
 {% block title %}{{ activity.title }} - Gatherly{% endblock %}
 
 {% block content %}
-<style>
-.star-rating {
-    display: flex;
-    flex-direction: row-reverse;
-    justify-content: flex-end;
-}
-.star-rating input {
-    display: none;
-}
-.star-rating label {
-    font-size: 24px;
-    color: #ccc;
-    cursor: pointer;
-    padding: 0 2px;
-}
-.star-rating input:checked ~ label,
-.star-rating label:hover,
-.star-rating label:hover ~ label {
-    color: #ffc107;
-}
-.rating-section {
-    margin-top: 24px;
-    padding: 20px;
-    background: #f9f9f9;
-    border-radius: 8px;
-}
-.rating-dimension {
-    margin-bottom: 16px;
-}
-.rating-dimension h4 {
-    margin-bottom: 8px;
-    font-size: 16px;
-    color: #333;
-}
-</style>
+
 <section class="section">
     <div class="container narrow-page">
         <!-- 返回首页 -->
@@ -137,49 +103,78 @@
         </div>
 
         <!-- 多维度评分 -->
-        {% if can_rate %}
         <div class="rating-section">
-            <h3>活动评分</h3>
-            <form method="post" action="{{ url_for('activity.submit_rating', activity_id=activity.id) }}">
+            <div class="rating-header">
+                <h3>活动评分</h3>
+                {% if rating_stats.count %}
+                    <span class="rating-count">{{ rating_stats.count }} 人已评分</span>
+                {% endif %}
+            </div>
+
+            {% if rating_stats.count %}
+            <div class="rating-summary">
+                <div class="rating-overall">
+                    <span class="rating-overall-label">综合平均分</span>
+                    <strong>{{ rating_stats.overall_avg }}</strong>
+                    <span>/ 5</span>
+                </div>
+                <div class="rating-averages">
+                    <div class="rating-average-item">
+                        <span>组织能力</span>
+                        <strong>{{ rating_stats.organization_avg }}</strong>
+                    </div>
+                    <div class="rating-average-item">
+                        <span>场地环境</span>
+                        <strong>{{ rating_stats.venue_avg }}</strong>
+                    </div>
+                    <div class="rating-average-item">
+                        <span>活动体验</span>
+                        <strong>{{ rating_stats.experience_avg }}</strong>
+                    </div>
+                </div>
+            </div>
+            {% else %}
+                <p class="rating-empty">暂无评分</p>
+            {% endif %}
+
+            {% if can_rate %}
+            <form class="rating-form" method="post" action="{{ url_for('activity.submit_rating', activity_id=activity.id) }}">
                 <div class="rating-dimension">
                     <h4>组织能力</h4>
-                    <div class="star-rating">
-                        <input type="radio" id="org5" name="organization_score" value="5"><label for="org5">★</label>
-                        <input type="radio" id="org4" name="organization_score" value="4"><label for="org4">★</label>
-                        <input type="radio" id="org3" name="organization_score" value="3"><label for="org3">★</label>
-                        <input type="radio" id="org2" name="organization_score" value="2"><label for="org2">★</label>
-                        <input type="radio" id="org1" name="organization_score" value="1"><label for="org1">★</label>
+                    <div class="star-rating" aria-label="组织能力评分">
+                        <input type="radio" id="org5" name="organization_score" value="5" required><label for="org5">&#9733;</label>
+                        <input type="radio" id="org4" name="organization_score" value="4"><label for="org4">&#9733;</label>
+                        <input type="radio" id="org3" name="organization_score" value="3"><label for="org3">&#9733;</label>
+                        <input type="radio" id="org2" name="organization_score" value="2"><label for="org2">&#9733;</label>
+                        <input type="radio" id="org1" name="organization_score" value="1"><label for="org1">&#9733;</label>
                     </div>
                 </div>
                 <div class="rating-dimension">
                     <h4>场地环境</h4>
-                    <div class="star-rating">
-                        <input type="radio" id="venue5" name="venue_score" value="5"><label for="venue5">★</label>
-                        <input type="radio" id="venue4" name="venue_score" value="4"><label for="venue4">★</label>
-                        <input type="radio" id="venue3" name="venue_score" value="3"><label for="venue3">★</label>
-                        <input type="radio" id="venue2" name="venue_score" value="2"><label for="venue2">★</label>
-                        <input type="radio" id="venue1" name="venue_score" value="1"><label for="venue1">★</label>
+                    <div class="star-rating" aria-label="场地环境评分">
+                        <input type="radio" id="venue5" name="venue_score" value="5" required><label for="venue5">&#9733;</label>
+                        <input type="radio" id="venue4" name="venue_score" value="4"><label for="venue4">&#9733;</label>
+                        <input type="radio" id="venue3" name="venue_score" value="3"><label for="venue3">&#9733;</label>
+                        <input type="radio" id="venue2" name="venue_score" value="2"><label for="venue2">&#9733;</label>
+                        <input type="radio" id="venue1" name="venue_score" value="1"><label for="venue1">&#9733;</label>
                     </div>
                 </div>
                 <div class="rating-dimension">
                     <h4>活动体验</h4>
-                    <div class="star-rating">
-                        <input type="radio" id="exp5" name="experience_score" value="5"><label for="exp5">★</label>
-                        <input type="radio" id="exp4" name="experience_score" value="4"><label for="exp4">★</label>
-                        <input type="radio" id="exp3" name="experience_score" value="3"><label for="exp3">★</label>
-                        <input type="radio" id="exp2" name="experience_score" value="2"><label for="exp2">★</label>
-                        <input type="radio" id="exp1" name="experience_score" value="1"><label for="exp1">★</label>
+                    <div class="star-rating" aria-label="活动体验评分">
+                        <input type="radio" id="exp5" name="experience_score" value="5" required><label for="exp5">&#9733;</label>
+                        <input type="radio" id="exp4" name="experience_score" value="4"><label for="exp4">&#9733;</label>
+                        <input type="radio" id="exp3" name="experience_score" value="3"><label for="exp3">&#9733;</label>
+                        <input type="radio" id="exp2" name="experience_score" value="2"><label for="exp2">&#9733;</label>
+                        <input type="radio" id="exp1" name="experience_score" value="1"><label for="exp1">&#9733;</label>
                     </div>
                 </div>
-                <button type="submit" class="btn" style="background-color:#28a745;color:#fff;border:none;padding:10px 24px;border-radius:4px;cursor:pointer;font-size:16px;">提交评分</button>
+                <button type="submit" class="btn rating-submit">提交评分</button>
             </form>
+            {% elif rating_notice %}
+                <p class="rating-notice">{{ rating_notice }}</p>
+            {% endif %}
         </div>
-        {% endif %}
-        {% if has_rated %}
-        <div class="rating-section">
-            <p style="color:#28a745;font-size:16px;">感谢您的评分！</p>
-        </div>
-        {% endif %}
     </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## 关联 Issue
Related to #50

## 修复背景
US-09-02 多维度评分功能已合并，但后续自检发现仍需要补充后端校验、重复评分限制、评分展示和数据库唯一约束。

## 本次修复内容
- 为 Rating 增加 activity_id + user_id 唯一约束，防止同一用户重复评分
- submit_rating 增加登录、报名/参加状态、活动已结束、重复评分校验
- 校验 organization_score、venue_score、experience_score 必须为 1-5 整数
- 保存三个维度评分，并计算 average_score
- 活动详情页展示综合平均分、三个维度平均分和评分人数
- 无评分时显示“暂无评分”
- 将评分相关样式移入 style.css，减少模板内联样式

## 自测情况
- [x] python -m compileall app 通过
- [x] create_app 路由加载通过
- [x] git diff --check 通过
- [x] 已登录、已报名、活动已结束用户可以评分
- [x] 未登录用户不能评分
- [x] 未报名用户不能评分
- [x] 活动未结束用户不能评分
- [x] 重复评分会被拦截

## 数据库说明
本次修改涉及 Rating 表字段和唯一约束。开发环境如果已有旧版 gatherly.db，db.create_all() 不会自动补充唯一约束，建议备份后重建数据库或单独迁移 rating 表。

## 主要修改文件
- app/models.py
- app/routes/activity.py
- app/templates/activity_detail.html
- app/static/css/style.css