### PR TITLE
fix(US-07-01): 修复圈子页面登录状态判断错误

### DIFF
--- a/app/templates/circle.html
+++ b/app/templates/circle.html
@@ -24,7 +24,7 @@
                         <p>{{ circle.members }} 位成员</p>
                         <p>{{ circle.activity_count }} 场本月活动</p>
                     </div>
-                    {% if current_user.is_authenticated %}
+                    {% if session.get("user_id") %}
                     <a class="button button-small" href="{{ url_for('circle.create_post', circle_id=circle.id) }}" style="margin-top: 12px; width: 100%; text-align: center;">
                         发布帖子
                     </a>


### PR DESCRIPTION
## 关联 Issue
关联 [US-07-01] 用户浏览兴趣圈子列表

## 本次修复内容
- 修复 circle.html 中使用 current_user 导致的 Jinja UndefinedError
- 将 current_user.is_authenticated 改为 session.get("user_id")
- 未引入 Flask-Login
- 未修改 models.py、activity.py、auth.py

## 自测情况
- [x] python -m compileall app 通过
- [x] python run.py 可启动
- [x] 未登录访问 /circles 返回 200
- [x] 登录后显示发布帖子入口