### PR TITLE
feat(US-16-05): 增加管理员账号设置页面

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,8 +1,10 @@
 from functools import wraps
 
 from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from sqlalchemy.exc import IntegrityError
+from werkzeug.security import check_password_hash, generate_password_hash
 
-from app.models import User
+from app.models import User, db
 
 admin_bp = Blueprint("admin", __name__)
 
@@ -37,3 +39,54 @@ def inject_current_user():
 @admin_required
 def admin_dashboard():
     return render_template("admin_dashboard.html")
+
+
+@admin_bp.route("/admin/account", methods=["GET", "POST"])
+@admin_required
+def admin_account():
+    user = get_current_user()
+
+    if request.method == "POST":
+        nickname = request.form.get("nickname", "").strip()
+        username = request.form.get("username", "").strip()
+        email = request.form.get("email", "").strip()
+        current_password = request.form.get("current_password", "")
+        new_password = request.form.get("new_password", "")
+        confirm_password = request.form.get("confirm_password", "")
+
+        if not nickname:
+            flash("昵称不能为空。", "error")
+        elif not username:
+            flash("用户名不能为空。", "error")
+        elif not email:
+            flash("邮箱不能为空。", "error")
+        elif not current_password or not check_password_hash(user.password, current_password):
+            flash("当前密码错误，无法保存管理员账号信息。", "error")
+        elif User.query.filter(User.username == username, User.id != user.id).first():
+            flash("该用户名已被其他用户占用，请更换后重试。", "error")
+        elif User.query.filter(User.email == email, User.id != user.id).first():
+            flash("该邮箱已被其他用户占用，请更换后重试。", "error")
+        elif confirm_password and not new_password:
+            flash("请输入新密码。", "error")
+        elif new_password and new_password != confirm_password:
+            flash("新密码和确认新密码不一致，无法保存。", "error")
+        elif new_password and len(new_password) < 6:
+            flash("新密码至少需要 6 个字符。", "error")
+        else:
+            user.nickname = nickname
+            user.username = username
+            user.email = email
+            if new_password:
+                user.password = generate_password_hash(new_password)
+
+            try:
+                db.session.commit()
+            except IntegrityError:
+                db.session.rollback()
+                flash("用户名或邮箱已被其他用户占用，请更换后重试。", "error")
+            else:
+                session["nickname"] = user.nickname or user.username
+                flash("管理员账号信息已更新", "success")
+                return redirect(url_for("admin.admin_account"))
+
+    return render_template("admin_account.html", user=user)

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2116,8 +2116,38 @@ textarea.form-input {
   color: var(--color-muted);
 }
 
+.admin-account-form {
+  display: grid;
+  gap: 28px;
+  margin-top: 24px;
+}
+
+.admin-account-section {
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.admin-account-section:last-of-type {
+  border-bottom: 0;
+}
+
+.admin-account-section h2 {
+  margin-bottom: 20px;
+  color: var(--color-primary-dark);
+  font-size: 20px;
+}
+
+.admin-account-form .form-actions {
+  margin-top: 0;
+}
+
 @media (max-width: 720px) {
   .admin-grid {
     grid-template-columns: 1fr;
+  }
+
+  .admin-account-form {
+    gap: 20px;
+    padding: 20px 16px;
   }
 }

--- a/app/templates/admin_account.html
+++ b/app/templates/admin_account.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block title %}管理员账号设置 - Gatherly{% endblock %}
+
+{% block content %}
+<section class="section">
+  <div class="container narrow-page">
+    <a class="back-link" href="{{ url_for('admin.admin_dashboard') }}">返回后台管理</a>
+    <div class="page-title">
+      <p class="eyebrow">Admin Account</p>
+      <h1>账号设置</h1>
+      <p>修改管理员账号信息。保存任何修改前，都需要输入当前密码确认身份。</p>
+    </div>
+
+    <form class="form-card admin-account-form" method="post">
+      <div class="admin-account-section">
+        <h2>基本信息</h2>
+        <div class="form-group">
+          <label class="form-label" for="nickname">昵称</label>
+          <input class="form-input" id="nickname" name="nickname" value="{{ user.nickname or '' }}" maxlength="80" required>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="username">用户名</label>
+          <input class="form-input" id="username" name="username" value="{{ user.username }}" maxlength="80" autocomplete="username" required>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="email">邮箱</label>
+          <input class="form-input" id="email" name="email" type="email" value="{{ user.email }}" maxlength="120" autocomplete="email" required>
+        </div>
+      </div>
+
+      <div class="admin-account-section">
+        <h2>身份确认与密码</h2>
+        <div class="form-group">
+          <label class="form-label" for="current_password">当前密码</label>
+          <input class="form-input" id="current_password" name="current_password" type="password" autocomplete="current-password" required>
+          <p class="form-hint">保存昵称、用户名或邮箱修改时，也必须输入当前密码。</p>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="new_password">新密码</label>
+          <input class="form-input" id="new_password" name="new_password" type="password" minlength="6" autocomplete="new-password">
+          <p class="form-hint">不修改密码时请留空；新密码至少需要 6 个字符。</p>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="confirm_password">确认新密码</label>
+          <input class="form-input" id="confirm_password" name="confirm_password" type="password" minlength="6" autocomplete="new-password">
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <button class="button" type="submit">保存账号设置</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -12,6 +12,10 @@
     </div>
 
     <div class="admin-grid" aria-label="后台管理导航">
+      <a class="admin-card" href="{{ url_for('admin.admin_account') }}">
+        <h2>账号设置</h2>
+        <p>修改管理员昵称、登录账号、邮箱和密码。</p>
+      </a>
       <a class="admin-card" href="#user-management">
         <h2>用户管理</h2>
         <p>查看和维护平台用户信息。</p>


### PR DESCRIPTION
## 关联 Issue
US-16-05

## 本次完成内容
- 新增管理员账号设置页面
- 管理员可以修改 nickname、username、email
- 管理员可以修改密码
- 修改敏感信息前需要输入当前密码
- 普通用户和未登录用户不能访问 /admin/account
- 页面不允许修改 role 字段

## 自测情况
- [x] git diff --check 通过
- [x] python -m compileall app 通过
- [x] app.url_map 可正常输出
- [x] 管理员可以访问 /admin/account
- [x] 普通用户不能访问 /admin/account
- [x] 修改昵称、邮箱、密码测试通过

## 主要修改文件
- app/routes/admin.py
- app/templates/admin_account.html
- app/templates/admin_dashboard.html
- app/templates/base.html
- app/static/css/style.css

## 需要 Review 的重点
请重点检查管理员账号设置是否不会修改 role，以及密码是否仍然使用哈希保存。