### PR TITLE
feat(US-16-02): 实现管理员内容管理列表

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,7 @@ class User(db.Model):
     interests = db.Column(db.Text)
     role = db.Column(db.String(20), default="user", nullable=False)
     trust_score = db.Column(db.Integer, default=100, nullable=False)
+    status = db.Column(db.String(20), default="active", nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
     activities = db.relationship("Activity", back_populates="organizer")
@@ -93,6 +94,7 @@ class Circle(db.Model):
     owner_id = db.Column(db.Integer, db.ForeignKey("user.id"))
     is_system = db.Column(db.Boolean, default=False, nullable=False)
     member_count = db.Column(db.Integer, default=0, nullable=False)
+    status = db.Column(db.String(20), default="active", nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
     posts = db.relationship("Post", back_populates="circle")

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,18 +1,25 @@
 from functools import wraps
 
 from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from sqlalchemy import func, text
 from sqlalchemy.exc import IntegrityError
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from app.models import User, db
+from app.models import Activity, AdminLog, Circle, Comment, Post, User, db
 
 admin_bp = Blueprint("admin", __name__)
+
+USER_STATUSES = {"active", "banned"}
+ACTIVITY_STATUSES = {"open", "hidden", "closed"}
+CIRCLE_STATUSES = {"active", "hidden"}
+CONTENT_STATUSES = {"published", "hidden"}
 
 
 def get_current_user():
     user_id = session.get("user_id")
     if not user_id:
         return None
+    _ensure_admin_schema()
     return User.query.get(user_id)
 
 
@@ -30,6 +37,71 @@ def admin_required(view):
     return wrapped_view
 
 
+def _ensure_admin_schema():
+    AdminLog.__table__.create(db.engine, checkfirst=True)
+    if db.engine.dialect.name != "sqlite":
+        return
+
+    table_columns = {
+        "user": ("status", "ALTER TABLE user ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'"),
+        "activity": ("status", "ALTER TABLE activity ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'"),
+        "circle": ("status", "ALTER TABLE circle ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'"),
+        "post": ("status", "ALTER TABLE post ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'published'"),
+        "comment": ("status", "ALTER TABLE comment ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'published'"),
+    }
+    changed = False
+    for table_name, (column_name, statement) in table_columns.items():
+        rows = db.session.execute(text(f'PRAGMA table_info("{table_name}")')).fetchall()
+        if rows and column_name not in {row[1] for row in rows}:
+            db.session.execute(text(statement))
+            changed = True
+    if changed:
+        db.session.commit()
+
+
+@admin_bp.before_app_request
+def ensure_admin_schema():
+    _ensure_admin_schema()
+
+
+def _log_admin_action(action, target_type, target_id, detail):
+    db.session.add(
+        AdminLog(
+            admin_id=get_current_user().id,
+            action=action,
+            target_type=target_type,
+            target_id=target_id,
+            detail=detail,
+            ip_address=request.remote_addr,
+        )
+    )
+
+
+def _update_status(model, target_id, allowed_statuses, target_type, list_endpoint):
+    _ensure_admin_schema()
+    target = model.query.get_or_404(target_id)
+    new_status = request.form.get("status", "").strip()
+    if new_status not in allowed_statuses:
+        flash("无效的状态值，未进行修改。", "error")
+        return redirect(url_for(list_endpoint))
+
+    previous_status = target.status
+    if previous_status == new_status:
+        flash("状态没有变化。", "success")
+        return redirect(url_for(list_endpoint))
+
+    target.status = new_status
+    _log_admin_action(
+        "update_status",
+        target_type,
+        target.id,
+        f"{previous_status} -> {new_status}",
+    )
+    db.session.commit()
+    flash(f"{target_type} #{target.id} 状态已更新为 {new_status}。", "success")
+    return redirect(url_for(list_endpoint))
+
+
 @admin_bp.app_context_processor
 def inject_current_user():
     return {"current_user": get_current_user()}
@@ -38,7 +110,109 @@ def inject_current_user():
 @admin_bp.route("/admin")
 @admin_required
 def admin_dashboard():
-    return render_template("admin_dashboard.html")
+    _ensure_admin_schema()
+    stats = {
+        "users": User.query.count(),
+        "activities": Activity.query.count(),
+        "circles": Circle.query.count(),
+        "posts": Post.query.count(),
+        "comments": Comment.query.count(),
+    }
+    logs = AdminLog.query.order_by(AdminLog.created_at.desc()).limit(30).all()
+    return render_template("admin_dashboard.html", stats=stats, logs=logs)
+
+
+@admin_bp.route("/admin/users")
+@admin_required
+def admin_users():
+    _ensure_admin_schema()
+    users = User.query.order_by(User.created_at.desc(), User.id.desc()).all()
+    return render_template("admin_users.html", users=users)
+
+
+@admin_bp.route("/admin/users/<int:user_id>/status", methods=["POST"])
+@admin_required
+def update_user_status(user_id):
+    return _update_status(User, user_id, USER_STATUSES, "用户", "admin.admin_users")
+
+
+@admin_bp.route("/admin/activities")
+@admin_required
+def admin_activities():
+    _ensure_admin_schema()
+    activities = Activity.query.order_by(Activity.created_at.desc(), Activity.id.desc()).all()
+    return render_template("admin_activities.html", activities=activities)
+
+
+@admin_bp.route("/admin/activities/<int:activity_id>/status", methods=["POST"])
+@admin_required
+def update_activity_status(activity_id):
+    return _update_status(
+        Activity,
+        activity_id,
+        ACTIVITY_STATUSES,
+        "活动",
+        "admin.admin_activities",
+    )
+
+
+@admin_bp.route("/admin/circles")
+@admin_required
+def admin_circles():
+    _ensure_admin_schema()
+    circles = (
+        db.session.query(Circle, func.count(Post.id).label("post_count"))
+        .outerjoin(Post, Post.circle_id == Circle.id)
+        .group_by(Circle.id)
+        .order_by(Circle.created_at.desc(), Circle.id.desc())
+        .all()
+    )
+    return render_template("admin_circles.html", circles=circles)
+
+
+@admin_bp.route("/admin/circles/<int:circle_id>/status", methods=["POST"])
+@admin_required
+def update_circle_status(circle_id):
+    _ensure_admin_schema()
+    circle = Circle.query.get_or_404(circle_id)
+    if not circle.is_system:
+        flash("仅允许修改官方圈子状态。", "error")
+        return redirect(url_for("admin.admin_circles"))
+    return _update_status(Circle, circle_id, CIRCLE_STATUSES, "同好圈", "admin.admin_circles")
+
+
+@admin_bp.route("/admin/posts")
+@admin_required
+def admin_posts():
+    _ensure_admin_schema()
+    posts = Post.query.order_by(Post.created_at.desc(), Post.id.desc()).all()
+    return render_template("admin_posts.html", posts=posts)
+
+
+@admin_bp.route("/admin/posts/<int:post_id>/status", methods=["POST"])
+@admin_required
+def update_post_status(post_id):
+    return _update_status(Post, post_id, CONTENT_STATUSES, "帖子", "admin.admin_posts")
+
+
+@admin_bp.route("/admin/comments")
+@admin_required
+def admin_comments():
+    _ensure_admin_schema()
+    comments = Comment.query.order_by(Comment.created_at.desc(), Comment.id.desc()).all()
+    return render_template("admin_comments.html", comments=comments)
+
+
+@admin_bp.route("/admin/comments/<int:comment_id>/status", methods=["POST"])
+@admin_required
+def update_comment_status(comment_id):
+    return _update_status(
+        Comment,
+        comment_id,
+        CONTENT_STATUSES,
+        "评论",
+        "admin.admin_comments",
+    )
 
 
 @admin_bp.route("/admin/account", methods=["GET", "POST"])

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2116,6 +2116,137 @@ textarea.form-input {
   color: var(--color-muted);
 }
 
+.admin-card strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--color-primary);
+  font-size: 34px;
+  line-height: 1;
+}
+
+.admin-nav {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 28px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+  scrollbar-width: thin;
+}
+
+.admin-nav a {
+  flex: 0 0 auto;
+  padding: 7px 11px;
+  border-radius: 999px;
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.admin-nav a:hover,
+.admin-nav a.is-active {
+  background: #e8f0ed;
+  color: var(--color-primary-dark);
+}
+
+.admin-panel {
+  margin-top: 36px;
+}
+
+.admin-panel-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.admin-panel-heading h2,
+.admin-panel-heading p {
+  margin-bottom: 0;
+}
+
+.admin-panel-heading > p,
+.admin-muted {
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.admin-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-surface);
+  box-shadow: 0 8px 20px rgba(34, 34, 34, 0.05);
+}
+
+.admin-table {
+  width: 100%;
+  min-width: 780px;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 13px 14px;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.admin-table th {
+  background: #fbfaf7;
+  color: var(--color-primary-dark);
+  white-space: nowrap;
+}
+
+.admin-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.admin-summary {
+  max-width: 280px;
+}
+
+.admin-empty {
+  padding: 24px !important;
+  color: var(--color-muted);
+  text-align: center !important;
+}
+
+.admin-status {
+  display: inline-flex;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #e8f0ed;
+  color: var(--color-primary-dark);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.admin-status.status-hidden,
+.admin-status.status-banned,
+.admin-status.status-closed {
+  background: #f4e4df;
+  color: #8b4638;
+}
+
+.admin-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.admin-action select {
+  min-height: 36px;
+  padding: 0 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  font: inherit;
+}
+
 .admin-account-form {
   display: grid;
   gap: 28px;
@@ -2149,5 +2280,11 @@ textarea.form-input {
   .admin-account-form {
     gap: 20px;
     padding: 20px 16px;
+  }
+
+  .admin-panel-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
   }
 }

--- a/app/templates/admin_account.html
+++ b/app/templates/admin_account.html
@@ -5,7 +5,16 @@
 {% block content %}
 <section class="section">
   <div class="container narrow-page">
-    <a class="back-link" href="{{ url_for('admin.admin_dashboard') }}">返回后台管理</a>
+    <nav class="admin-nav" aria-label="后台管理导航">
+      <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a>
+      <a class="is-active" href="{{ url_for('admin.admin_account') }}">账号设置</a>
+      <a href="{{ url_for('admin.admin_users') }}">用户</a>
+      <a href="{{ url_for('admin.admin_activities') }}">活动</a>
+      <a href="{{ url_for('admin.admin_circles') }}">同好圈</a>
+      <a href="{{ url_for('admin.admin_posts') }}">帖子</a>
+      <a href="{{ url_for('admin.admin_comments') }}">评论</a>
+      <a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+    </nav>
     <div class="page-title">
       <p class="eyebrow">Admin Account</p>
       <h1>账号设置</h1>

--- a/app/templates/admin_activities.html
+++ b/app/templates/admin_activities.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}活动管理 - Gatherly{% endblock %}
+{% block content %}
+<section class="section"><div class="container">
+  <nav class="admin-nav" aria-label="后台管理导航">
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a class="is-active" href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+  </nav>
+  <div class="page-title"><p class="eyebrow">Admin Activities</p><h1>活动管理</h1><p>查看活动并维护 open、hidden 或 closed 状态。</p></div>
+  <div class="admin-table-wrap"><table class="admin-table">
+    <thead><tr><th>ID</th><th>标题</th><th>组织者</th><th>地点</th><th>开始时间</th><th>状态</th><th>操作</th></tr></thead>
+    <tbody>{% for activity in activities %}<tr>
+      <td>{{ activity.id }}</td><td>{{ activity.title }}</td><td>{{ activity.organizer.username }}</td><td>{{ activity.location or '-' }}</td><td>{{ activity.start_time.strftime('%Y-%m-%d %H:%M') if activity.start_time else '-' }}</td><td><span class="admin-status status-{{ activity.status }}">{{ activity.status }}</span></td>
+      <td><form class="admin-action" method="post" action="{{ url_for('admin.update_activity_status', activity_id=activity.id) }}"><select name="status" aria-label="修改 {{ activity.title }} 的状态">{% for status in ['open', 'hidden', 'closed'] %}<option value="{{ status }}" {% if activity.status == status %}selected{% endif %}>{{ status }}</option>{% endfor %}</select><button class="button button-small" type="submit">保存</button></form></td>
+    </tr>{% else %}<tr><td class="admin-empty" colspan="7">暂无活动。</td></tr>{% endfor %}</tbody>
+  </table></div>
+</div></section>
+{% endblock %}

--- a/app/templates/admin_circles.html
+++ b/app/templates/admin_circles.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}同好圈管理 - Gatherly{% endblock %}
+{% block content %}
+<section class="section"><div class="container">
+  <nav class="admin-nav" aria-label="后台管理导航">
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a class="is-active" href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+  </nav>
+  <div class="page-title"><p class="eyebrow">Admin Circles</p><h1>同好圈管理</h1><p>查看同好圈，并维护官方圈子状态。</p></div>
+  <div class="admin-table-wrap"><table class="admin-table">
+    <thead><tr><th>ID</th><th>名称</th><th>标签</th><th>是否官方</th><th>帖子数</th><th>状态</th><th>操作</th></tr></thead>
+    <tbody>{% for circle, post_count in circles %}<tr>
+      <td>{{ circle.id }}</td><td>{{ circle.name }}</td><td>{{ circle.tag or '-' }}</td><td>{{ '是' if circle.is_system else '否' }}</td><td>{{ post_count }}</td><td><span class="admin-status status-{{ circle.status }}">{{ circle.status }}</span></td>
+      <td>{% if circle.is_system %}<form class="admin-action" method="post" action="{{ url_for('admin.update_circle_status', circle_id=circle.id) }}"><select name="status" aria-label="修改 {{ circle.name }} 的状态"><option value="active" {% if circle.status == 'active' %}selected{% endif %}>active</option><option value="hidden" {% if circle.status == 'hidden' %}selected{% endif %}>hidden</option></select><button class="button button-small" type="submit">保存</button></form>{% else %}<span class="admin-muted">仅官方圈子可管理</span>{% endif %}</td>
+    </tr>{% else %}<tr><td class="admin-empty" colspan="7">暂无同好圈。</td></tr>{% endfor %}</tbody>
+  </table></div>
+</div></section>
+{% endblock %}

--- a/app/templates/admin_comments.html
+++ b/app/templates/admin_comments.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}评论管理 - Gatherly{% endblock %}
+{% block content %}
+<section class="section"><div class="container">
+  <nav class="admin-nav" aria-label="后台管理导航">
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a class="is-active" href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+  </nav>
+  <div class="page-title"><p class="eyebrow">Admin Comments</p><h1>评论管理</h1><p>评论和评论回复统一展示，可隐藏或恢复。</p></div>
+  <div class="admin-table-wrap"><table class="admin-table">
+    <thead><tr><th>ID</th><th>作者</th><th>内容摘要</th><th>所属内容</th><th>状态</th><th>发布时间</th><th>操作</th></tr></thead>
+    <tbody>{% for comment in comments %}<tr>
+      <td>{{ comment.id }}</td><td>{{ comment.author.username }}</td><td class="admin-summary">{{ comment.content|truncate(60, true) }}</td><td>{% if comment.parent_id %}回复评论 #{{ comment.parent_id }}{% elif comment.post %}帖子 #{{ comment.post.id }}{% elif comment.activity %}活动 #{{ comment.activity.id }}{% else %}-{% endif %}</td><td><span class="admin-status status-{{ comment.status }}">{{ comment.status }}</span></td><td>{{ comment.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+      <td><form method="post" action="{{ url_for('admin.update_comment_status', comment_id=comment.id) }}"><input type="hidden" name="status" value="{{ 'published' if comment.status == 'hidden' else 'hidden' }}"><button class="button button-small {% if comment.status != 'hidden' %}button-secondary{% endif %}" type="submit">{{ '恢复' if comment.status == 'hidden' else '隐藏' }}</button></form></td>
+    </tr>{% else %}<tr><td class="admin-empty" colspan="7">暂无评论。</td></tr>{% endfor %}</tbody>
+  </table></div>
+</div></section>
+{% endblock %}

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -5,42 +5,57 @@
 {% block content %}
 <section class="section">
   <div class="container">
+    <nav class="admin-nav" aria-label="后台管理导航">
+      <a class="is-active" href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a>
+      <a href="{{ url_for('admin.admin_account') }}">账号设置</a>
+      <a href="{{ url_for('admin.admin_users') }}">用户</a>
+      <a href="{{ url_for('admin.admin_activities') }}">活动</a>
+      <a href="{{ url_for('admin.admin_circles') }}">同好圈</a>
+      <a href="{{ url_for('admin.admin_posts') }}">帖子</a>
+      <a href="{{ url_for('admin.admin_comments') }}">评论</a>
+      <a href="#operation-logs">操作日志</a>
+    </nav>
+
     <div class="page-title">
       <p class="eyebrow">Admin Dashboard</p>
       <h1>后台管理</h1>
-      <p>欢迎进入 Gatherly 后台管理系统。请选择需要管理的模块。</p>
+      <p>查看平台内容概况，并进入对应模块维护状态。</p>
     </div>
 
-    <div class="admin-grid" aria-label="后台管理导航">
-      <a class="admin-card" href="{{ url_for('admin.admin_account') }}">
-        <h2>账号设置</h2>
-        <p>修改管理员昵称、登录账号、邮箱和密码。</p>
-      </a>
-      <a class="admin-card" href="#user-management">
-        <h2>用户管理</h2>
-        <p>查看和维护平台用户信息。</p>
-      </a>
-      <a class="admin-card" href="#activity-management">
-        <h2>活动管理</h2>
-        <p>管理活动内容和活动状态。</p>
-      </a>
-      <a class="admin-card" href="#circle-management">
-        <h2>同好圈管理</h2>
-        <p>维护同好圈和圈内秩序。</p>
-      </a>
-      <a class="admin-card" href="#post-management">
-        <h2>帖子管理</h2>
-        <p>查看和处理社区帖子。</p>
-      </a>
-      <a class="admin-card" href="#comment-management">
-        <h2>评论管理</h2>
-        <p>查看和处理用户评论。</p>
-      </a>
-      <a class="admin-card" href="#operation-logs">
-        <h2>操作日志</h2>
-        <p>查看后台管理操作记录。</p>
-      </a>
+    <div class="admin-grid" aria-label="后台管理模块">
+      <a class="admin-card" href="{{ url_for('admin.admin_users') }}"><h2>用户</h2><strong>{{ stats.users }}</strong><p>查看账号并维护用户状态。</p></a>
+      <a class="admin-card" href="{{ url_for('admin.admin_activities') }}"><h2>活动</h2><strong>{{ stats.activities }}</strong><p>维护活动公开状态。</p></a>
+      <a class="admin-card" href="{{ url_for('admin.admin_circles') }}"><h2>同好圈</h2><strong>{{ stats.circles }}</strong><p>维护官方圈子状态。</p></a>
+      <a class="admin-card" href="{{ url_for('admin.admin_posts') }}"><h2>帖子</h2><strong>{{ stats.posts }}</strong><p>隐藏或恢复圈内帖子。</p></a>
+      <a class="admin-card" href="{{ url_for('admin.admin_comments') }}"><h2>评论</h2><strong>{{ stats.comments }}</strong><p>处理评论和评论回复。</p></a>
+      <a class="admin-card" href="{{ url_for('admin.admin_account') }}"><h2>账号设置</h2><p>修改管理员账号信息和密码。</p></a>
     </div>
+
+    <section class="admin-panel" id="operation-logs">
+      <div class="admin-panel-heading">
+        <div><p class="eyebrow">Audit Trail</p><h2>操作日志</h2></div>
+        <p>最近 30 条后台状态修改记录</p>
+      </div>
+      <div class="admin-table-wrap">
+        <table class="admin-table">
+          <thead><tr><th>时间</th><th>管理员</th><th>操作</th><th>对象</th><th>详情</th><th>IP</th></tr></thead>
+          <tbody>
+            {% for log in logs %}
+              <tr>
+                <td>{{ log.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+                <td>{{ log.admin.username }}</td>
+                <td>{{ log.action }}</td>
+                <td>{{ log.target_type }}{% if log.target_id %} #{{ log.target_id }}{% endif %}</td>
+                <td>{{ log.detail or '-' }}</td>
+                <td>{{ log.ip_address or '-' }}</td>
+              </tr>
+            {% else %}
+              <tr><td class="admin-empty" colspan="6">暂无后台操作日志。</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </section>
   </div>
 </section>
 {% endblock %}

--- a/app/templates/admin_posts.html
+++ b/app/templates/admin_posts.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}帖子管理 - Gatherly{% endblock %}
+{% block content %}
+<section class="section"><div class="container">
+  <nav class="admin-nav" aria-label="后台管理导航">
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a class="is-active" href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+  </nav>
+  <div class="page-title"><p class="eyebrow">Admin Posts</p><h1>帖子管理</h1><p>查看圈内帖子，并隐藏或恢复内容。</p></div>
+  <div class="admin-table-wrap"><table class="admin-table">
+    <thead><tr><th>ID</th><th>标题</th><th>作者</th><th>圈子</th><th>状态</th><th>发布时间</th><th>操作</th></tr></thead>
+    <tbody>{% for post in posts %}<tr>
+      <td>{{ post.id }}</td><td>{{ post.title }}</td><td>{{ post.user.username }}</td><td>{{ post.circle.name }}</td><td><span class="admin-status status-{{ post.status }}">{{ post.status }}</span></td><td>{{ post.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+      <td><form method="post" action="{{ url_for('admin.update_post_status', post_id=post.id) }}"><input type="hidden" name="status" value="{{ 'published' if post.status == 'hidden' else 'hidden' }}"><button class="button button-small {% if post.status != 'hidden' %}button-secondary{% endif %}" type="submit">{{ '恢复' if post.status == 'hidden' else '隐藏' }}</button></form></td>
+    </tr>{% else %}<tr><td class="admin-empty" colspan="7">暂无帖子。</td></tr>{% endfor %}</tbody>
+  </table></div>
+</div></section>
+{% endblock %}

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}用户管理 - Gatherly{% endblock %}
+{% block content %}
+<section class="section"><div class="container">
+  <nav class="admin-nav" aria-label="后台管理导航">
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a class="is-active" href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+  </nav>
+  <div class="page-title"><p class="eyebrow">Admin Users</p><h1>用户管理</h1><p>查看平台用户并维护账号状态。</p></div>
+  <div class="admin-table-wrap"><table class="admin-table">
+    <thead><tr><th>ID</th><th>用户名</th><th>邮箱</th><th>角色</th><th>信任分</th><th>创建时间</th><th>状态</th><th>操作</th></tr></thead>
+    <tbody>{% for user in users %}<tr>
+      <td>{{ user.id }}</td><td>{{ user.username }}</td><td>{{ user.email }}</td><td>{{ user.role }}</td><td>{{ user.trust_score }}</td><td>{{ user.created_at.strftime('%Y-%m-%d %H:%M') }}</td><td><span class="admin-status status-{{ user.status }}">{{ user.status }}</span></td>
+      <td><form class="admin-action" method="post" action="{{ url_for('admin.update_user_status', user_id=user.id) }}"><select name="status" aria-label="修改 {{ user.username }} 的状态"><option value="active" {% if user.status == 'active' %}selected{% endif %}>active</option><option value="banned" {% if user.status == 'banned' %}selected{% endif %}>banned</option></select><button class="button button-small" type="submit">保存</button></form></td>
+    </tr>{% else %}<tr><td class="admin-empty" colspan="8">暂无用户。</td></tr>{% endfor %}</tbody>
+  </table></div>
+</div></section>
+{% endblock %}


### PR DESCRIPTION
## 关联 Issue
Closes #144

## 本次完成内容
- 增加后台用户管理列表
- 增加后台活动管理列表
- 增加后台同好圈管理列表
- 增加后台帖子管理列表
- 增加后台评论管理列表
- 支持管理员修改用户、活动、圈子、帖子、评论状态
- 所有后台管理路由限制普通用户访问

## 自测情况
- [x] git diff --check 通过
- [x] python -m compileall app 通过
- [x] app.url_map 可正常输出
- [x] 管理员可以访问后台管理列表
- [x] 普通用户不能访问后台管理列表
- [x] 状态修改使用 POST
- [x] 状态修改后 flash 提示正常

## 主要修改文件
- app/routes/admin.py
- app/templates/admin_users.html
- app/templates/admin_activities.html
- app/templates/admin_circles.html
- app/templates/admin_posts.html
- app/templates/admin_comments.html
- app/templates/admin_dashboard.html
- app/static/css/style.css

## 需要 Review 的重点
请重点检查后台状态修改是否全部使用 POST，以及是否没有破坏普通用户功能。