### PR TITLE
feat(US-16-04): 增加管理员封禁和解封用户功能

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -17,6 +17,7 @@ class User(db.Model):
     role = db.Column(db.String(20), default="user", nullable=False)
     trust_score = db.Column(db.Integer, default=100, nullable=False)
     status = db.Column(db.String(20), default="active", nullable=False)
+    banned_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
     activities = db.relationship("Activity", back_populates="organizer")

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from functools import wraps
 
 from flask import Blueprint, flash, redirect, render_template, request, session, url_for
@@ -55,6 +56,12 @@ def _ensure_admin_schema():
         if rows and column_name not in {row[1] for row in rows}:
             db.session.execute(text(statement))
             changed = True
+    user_columns = {
+        row[1] for row in db.session.execute(text('PRAGMA table_info("user")')).fetchall()
+    }
+    if user_columns and "banned_at" not in user_columns:
+        db.session.execute(text("ALTER TABLE user ADD COLUMN banned_at DATETIME"))
+        changed = True
     if changed:
         db.session.commit()
 
@@ -166,10 +173,47 @@ def admin_users():
     return render_template("admin_users.html", users=users)
 
 
-@admin_bp.route("/admin/users/<int:user_id>/status", methods=["POST"])
+def _update_user_ban_status(user_id, new_status):
+    _ensure_admin_schema()
+    user = User.query.get_or_404(user_id)
+    admin = get_current_user()
+
+    if new_status == "banned" and user.id == admin.id:
+        flash("不能封禁当前登录的管理员账号。", "error")
+        return redirect(url_for("admin.admin_users"))
+
+    previous_status = user.status
+    if previous_status == new_status:
+        flash("账号状态没有变化。", "info")
+        return redirect(url_for("admin.admin_users"))
+    if previous_status not in USER_STATUSES:
+        flash("当前账号状态不支持此操作。", "error")
+        return redirect(url_for("admin.admin_users"))
+
+    user.status = new_status
+    user.banned_at = datetime.utcnow() if new_status == "banned" else None
+    log_admin_action(
+        admin.id,
+        "ban_user" if new_status == "banned" else "unban_user",
+        "用户",
+        user.id,
+        f"status: {previous_status} -> {new_status}",
+    )
+    db.session.commit()
+    flash("用户已封禁" if new_status == "banned" else "用户已解封", "success")
+    return redirect(url_for("admin.admin_users"))
+
+
+@admin_bp.route("/admin/users/<int:user_id>/ban", methods=["POST"])
 @admin_required
-def update_user_status(user_id):
-    return _update_status(User, user_id, USER_STATUSES, "用户", "admin.admin_users")
+def ban_user(user_id):
+    return _update_user_ban_status(user_id, "banned")
+
+
+@admin_bp.route("/admin/users/<int:user_id>/unban", methods=["POST"])
+@admin_required
+def unban_user(user_id):
+    return _update_user_ban_status(user_id, "active")
 
 
 @admin_bp.route("/admin/activities")

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -43,6 +43,10 @@ def login():
             flash("账号、邮箱或密码错误", "error")
             return render_template("login.html")
 
+        if user.status == "banned":
+            flash("该账号已被封禁", "error")
+            return render_template("login.html")
+
         # 登录成功，写入 session
         session.clear()
         session["user_id"] = user.id

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2247,6 +2247,26 @@ textarea.form-input {
   font: inherit;
 }
 
+.button.button-small.button-danger {
+  border-color: #8b4638;
+  background: #8b4638;
+}
+
+.button.button-small.button-danger:hover {
+  border-color: #71372d;
+  background: #71372d;
+}
+
+.profile-banned-notice {
+  margin-bottom: 18px;
+  padding: 14px 16px;
+  border: 1px solid #d9aaa0;
+  border-radius: 8px;
+  background: #f8e8e4;
+  color: #8b4638;
+  font-weight: 700;
+}
+
 .admin-account-form {
   display: grid;
   gap: 28px;

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -10,7 +10,17 @@
     <thead><tr><th>ID</th><th>用户名</th><th>邮箱</th><th>角色</th><th>信任分</th><th>创建时间</th><th>状态</th><th>操作</th></tr></thead>
     <tbody>{% for user in users %}<tr>
       <td>{{ user.id }}</td><td>{{ user.username }}</td><td>{{ user.email }}</td><td>{{ user.role }}</td><td>{{ user.trust_score }}</td><td>{{ user.created_at.strftime('%Y-%m-%d %H:%M') }}</td><td><span class="admin-status status-{{ user.status }}">{{ user.status }}</span></td>
-      <td><form class="admin-action" method="post" action="{{ url_for('admin.update_user_status', user_id=user.id) }}"><select name="status" aria-label="修改 {{ user.username }} 的状态"><option value="active" {% if user.status == 'active' %}selected{% endif %}>active</option><option value="banned" {% if user.status == 'banned' %}selected{% endif %}>banned</option></select><button class="button button-small" type="submit">保存</button></form></td>
+      <td>
+        {% if user.id == current_user.id %}
+          <span class="admin-muted">当前管理员，不可封禁</span>
+        {% elif user.status == 'active' %}
+          <form method="post" action="{{ url_for('admin.ban_user', user_id=user.id) }}"><button class="button button-small button-danger" type="submit">封禁</button></form>
+        {% elif user.status == 'banned' %}
+          <form method="post" action="{{ url_for('admin.unban_user', user_id=user.id) }}"><button class="button button-small" type="submit">解封</button></form>
+        {% else %}
+          <span class="admin-muted">当前状态不可操作</span>
+        {% endif %}
+      </td>
     </tr>{% else %}<tr><td class="admin-empty" colspan="8">暂无用户。</td></tr>{% endfor %}</tbody>
   </table></div>
 </div></section>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -5,6 +5,9 @@
 {% block content %}
 <section class="section">
   <div class="container">
+    {% if user.status == 'banned' %}
+    <div class="profile-banned-notice" role="status">该账号已被封禁</div>
+    {% endif %}
     <div class="detail-info-card">
       <div class="detail-info-row">
         <span class="detail-info-label">头像</span>


### PR DESCRIPTION
## 关联 Issue
Closes #164

## 本次完成内容
- 管理员用户管理列表显示账号状态
- 管理员可以封禁 active 用户
- 管理员可以解封 banned 用户
- 管理员不能封禁自己
- 被封禁用户不能继续登录
- 被封禁用户主页显示“该账号已被封禁”
- 封禁 / 解封操作写入 AdminLog

## 自测情况
- [x] git diff --check 通过
- [x] python -m compileall app 通过
- [x] app.url_map 可正常输出
- [x] 管理员可以封禁用户
- [x] 管理员可以解封用户
- [x] 管理员不能封禁自己
- [x] 被封禁用户不能登录
- [x] 被封禁用户主页显示“该账号已被封禁”
- [x] 用户帖子、评论、回复保留

## 主要修改文件
- app/models.py
- app/routes/admin.py
- app/templates/admin_users.html
- app/routes/auth.py
- app/templates/profile.html
- app/static/css/style.css

## 需要 Review 的重点
请重点检查封禁 / 解封是否全部使用 POST、是否禁止管理员封禁自己，以及是否没有删除用户历史内容。