### PR TITLE
feat(US-17-01): 增加用户账号注销功能

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import text
 
 
 db = SQLAlchemy()
@@ -18,6 +19,7 @@ class User(db.Model):
     trust_score = db.Column(db.Integer, default=100, nullable=False)
     status = db.Column(db.String(20), default="active", nullable=False)
     banned_at = db.Column(db.DateTime, nullable=True)
+    deleted_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
     activities = db.relationship("Activity", back_populates="organizer")
@@ -53,6 +55,24 @@ class User(db.Model):
         foreign_keys="AdminLog.admin_id",
         back_populates="admin",
     )
+
+
+def ensure_user_account_schema():
+    if db.engine.dialect.name != "sqlite":
+        return
+
+    rows = db.session.execute(text('PRAGMA table_info("user")')).fetchall()
+    existing_columns = {row[1] for row in rows}
+    if rows and "deleted_at" not in existing_columns:
+        db.session.execute(text('ALTER TABLE "user" ADD COLUMN deleted_at DATETIME'))
+        db.session.commit()
+
+
+def get_user_display_name(user):
+    if user.status == "deleted":
+        return "已注销用户"
+    return user.nickname or user.username
+
 
 class Activity(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,12 +1,26 @@
 # -*- coding: utf-8 -*-
 """认证相关路由（登录 / 注册 / 登出）"""
 
+from datetime import datetime
+
 from flask import Blueprint, render_template, redirect, url_for, flash, request, session
 from werkzeug.security import generate_password_hash, check_password_hash
-from app.models import db, User
+from app.models import User, db, ensure_user_account_schema
 from app.forms import RegistrationForm
 
 auth_bp = Blueprint("auth", __name__)
+
+
+@auth_bp.before_app_request
+def ensure_account_schema():
+    ensure_user_account_schema()
+
+
+def _get_session_user():
+    user_id = session.get("user_id")
+    if not user_id:
+        return None
+    return User.query.get(user_id)
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
@@ -39,6 +53,10 @@ def login():
             return render_template("login.html")
 
         # 验证密码
+        if user.status == "deleted":
+            flash("该账号已注销", "error")
+            return render_template("login.html")
+
         if not check_password_hash(user.password, password):
             flash("账号、邮箱或密码错误", "error")
             return render_template("login.html")
@@ -65,6 +83,51 @@ def logout():
     """退出登录，清除 session 并重定向到首页"""
     session.clear()
     flash("您已退出登录", "info")
+    return redirect(url_for("activity.index"))
+
+
+@auth_bp.route("/account/settings")
+def account_settings():
+    user = _get_session_user()
+    if user is None:
+        return redirect(url_for("auth.login", next=request.url))
+    if user.status == "deleted":
+        session.clear()
+        flash("该账号已注销", "error")
+        return redirect(url_for("activity.index"))
+    return render_template("account_settings.html", user=user)
+
+
+@auth_bp.route("/account/delete", methods=["POST"])
+def delete_account():
+    user = _get_session_user()
+    if user is None:
+        return redirect(url_for("auth.login", next=url_for("auth.account_settings")))
+    if user.status == "deleted":
+        session.clear()
+        flash("该账号已注销", "error")
+        return redirect(url_for("activity.index"))
+
+    current_password = request.form.get("current_password", "")
+    confirm_text = request.form.get("confirm_text", "").strip()
+    if not check_password_hash(user.password, current_password):
+        flash("当前密码错误", "error")
+        return redirect(url_for("auth.account_settings"))
+    if confirm_text != "注销账户":
+        flash("确认文字不正确", "error")
+        return redirect(url_for("auth.account_settings"))
+
+    old_email = user.email
+    user.status = "deleted"
+    user.deleted_at = datetime.utcnow()
+    user.username = f"deleted_user_{user.id}"
+    user.email = f"deleted_{user.id}_{old_email}"
+    user.nickname = "已注销用户"
+    user.avatar = None
+    db.session.commit()
+
+    session.clear()
+    flash("账号已注销", "success")
     return redirect(url_for("activity.index"))
 
 

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -17,6 +17,7 @@ from app.models import (
     User,
     UserReview,
     db,
+    get_user_display_name,
 )
 
 profile_bp = Blueprint("profile", __name__, url_prefix="/profile")
@@ -215,6 +216,10 @@ def my_profile():
 @profile_bp.route("/<int:user_id>")
 def view_profile(user_id):
     user = User.query.get_or_404(user_id)
+    display_name = get_user_display_name(user)
+    if user.status == "deleted":
+        return render_template("profile.html", user=user, display_name=display_name)
+
     is_owner = session.get("user_id") == user.id
     visibility = _get_or_create_visibility(user)
 
@@ -232,6 +237,7 @@ def view_profile(user_id):
     return render_template(
         "profile.html",
         user=user,
+        display_name=display_name,
         is_owner=is_owner,
         visibility=visibility,
         permissions=permissions,

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2267,6 +2267,43 @@ textarea.form-input {
   font-weight: 700;
 }
 
+.profile-deleted-notice {
+  padding: 18px 20px;
+  border: 1px solid #d9aaa0;
+  border-radius: 8px;
+  background: #f8e8e4;
+  color: #8b4638;
+  font-weight: 700;
+}
+
+.account-settings-container {
+  max-width: 720px;
+}
+
+.danger-zone {
+  margin-top: 24px;
+  padding: 24px;
+  border-color: #d9aaa0;
+}
+
+.danger-zone h2 {
+  color: #8b4638;
+}
+
+.danger-zone form {
+  margin-top: 20px;
+}
+
+.button.button-danger {
+  border-color: #8b4638;
+  background: #8b4638;
+}
+
+.button.button-danger:hover {
+  border-color: #71372d;
+  background: #71372d;
+}
+
 .admin-account-form {
   display: grid;
   gap: 28px;

--- a/app/templates/account_settings.html
+++ b/app/templates/account_settings.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}账号设置 - Gatherly{% endblock %}
+
+{% block content %}
+<section class="section">
+  <div class="container account-settings-container">
+    <a class="back-link" href="{{ url_for('profile.my_profile') }}">返回个人主页</a>
+    <h1>账号设置</h1>
+
+    <div class="form-card danger-zone">
+      <h2>注销账号</h2>
+      <p>注销后无法恢复。你的帖子、评论、回复和其他历史记录会保留，并统一显示为“已注销用户”。</p>
+      <form method="post" action="{{ url_for('auth.delete_account') }}">
+        <div class="form-group">
+          <label class="form-label" for="current_password">当前密码</label>
+          <input class="form-input" id="current_password" name="current_password" type="password" autocomplete="current-password" required>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="confirm_text">输入“注销账户”确认操作</label>
+          <input class="form-input" id="confirm_text" name="confirm_text" required>
+        </div>
+        <div class="form-actions">
+          <button class="button button-danger" type="submit">注销账号</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,6 +16,7 @@
         <li><a href="{{ url_for('circle.circles') }}">同好圈</a></li>
         {% if session.get('user_id') %}
           <li><a href="{{ url_for('profile.my_profile') }}">个人主页</a></li>
+          <li><a href="{{ url_for('auth.account_settings') }}">账号设置</a></li>
           {% if current_user and current_user.role == 'admin' %}
             <li><a href="{{ url_for('admin.admin_dashboard') }}">后台管理</a></li>
           {% endif %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,10 +1,13 @@
 {% extends "base.html" %}
 
-{% block title %}{{ user.nickname or user.username }} 的个人主页 - Gatherly{% endblock %}
+{% block title %}{{ display_name }} 的个人主页 - Gatherly{% endblock %}
 
 {% block content %}
 <section class="section">
   <div class="container">
+    {% if user.status == 'deleted' %}
+    <div class="profile-deleted-notice" role="status">该账号已注销</div>
+    {% else %}
     {% if user.status == 'banned' %}
     <div class="profile-banned-notice" role="status">该账号已被封禁</div>
     {% endif %}
@@ -131,6 +134,7 @@
         <p class="rating-empty">暂无同好圈互动记录。</p>
       {% endif %}
     </div>
+    {% endif %}
     {% endif %}
   </div>
 </section>


### PR DESCRIPTION
## 关联 Issue
Closes #165

## 本次完成内容
- 新增普通用户账号设置页
- 新增用户主动注销账号功能
- 注销前必须输入当前密码
- 注销前必须输入确认文字“注销账户”
- 注销后 User.status 变为 deleted
- 注销后自动退出登录
- 注销后旧账号不能再次登录
- 注销后释放原用户名和邮箱
- 注销后用户历史帖子、评论、回复保留
- 已注销用户主页显示“该账号已注销”

## 自测情况
- [x] git diff --check 通过
- [x] python -m compileall app 通过
- [x] app.url_map 可正常输出
- [x] 密码错误不能注销
- [x] 确认文字错误不能注销
- [x] 正确确认后可以注销
- [x] 注销后自动退出登录
- [x] 注销后不能再次登录
- [x] 注销后帖子、评论、回复保留
- [x] 已注销用户主页显示“该账号已注销”

## 主要修改文件
- app/models.py
- app/routes/auth.py
- app/routes/profile.py
- app/templates/account_settings.html
- app/templates/profile.html
- app/templates/base.html
- app/static/css/style.css

## 需要 Review 的重点
请重点检查注销是否不是硬删除、是否释放原邮箱和用户名、是否保留用户历史内容，以及是否不会影响管理员账号设置页面。