### PR TITLE
feat(US-16-06): 增加管理员权限授予和撤销功能

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -216,6 +216,64 @@ def unban_user(user_id):
     return _update_user_ban_status(user_id, "active")
 
 
+@admin_bp.route("/admin/users/<int:user_id>/promote-admin", methods=["POST"])
+@admin_required
+def promote_admin(user_id):
+    _ensure_admin_schema()
+    user = User.query.get_or_404(user_id)
+    admin = get_current_user()
+
+    if user.status != "active":
+        flash("只有正常状态的用户可以设为管理员。", "error")
+        return redirect(url_for("admin.admin_users"))
+    if user.role == "admin":
+        flash("该用户已经是管理员。", "info")
+        return redirect(url_for("admin.admin_users"))
+
+    previous_role = user.role
+    user.role = "admin"
+    log_admin_action(
+        admin.id,
+        "promote_admin",
+        "用户",
+        user.id,
+        f"role: {previous_role} -> admin",
+    )
+    db.session.commit()
+    flash("已设为管理员", "success")
+    return redirect(url_for("admin.admin_users"))
+
+
+@admin_bp.route("/admin/users/<int:user_id>/demote-admin", methods=["POST"])
+@admin_required
+def demote_admin(user_id):
+    _ensure_admin_schema()
+    user = User.query.get_or_404(user_id)
+    admin = get_current_user()
+
+    if user.id == admin.id:
+        flash("不能撤销自己的管理员权限。", "error")
+        return redirect(url_for("admin.admin_users"))
+    if user.role != "admin":
+        flash("该用户不是管理员。", "info")
+        return redirect(url_for("admin.admin_users"))
+    if User.query.filter_by(role="admin").count() <= 1:
+        flash("系统必须保留至少一个管理员。", "error")
+        return redirect(url_for("admin.admin_users"))
+
+    user.role = "user"
+    log_admin_action(
+        admin.id,
+        "demote_admin",
+        "用户",
+        user.id,
+        "role: admin -> user",
+    )
+    db.session.commit()
+    flash("已撤销管理员权限", "success")
+    return redirect(url_for("admin.admin_users"))
+
+
 @admin_bp.route("/admin/activities")
 @admin_required
 def admin_activities():

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2247,6 +2247,22 @@ textarea.form-input {
   font: inherit;
 }
 
+.admin-user-actions,
+.admin-action-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.admin-user-actions {
+  min-width: 180px;
+}
+
+.admin-action-group form {
+  margin: 0;
+}
+
 .button.button-small.button-danger {
   border-color: #8b4638;
   background: #8b4638;

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -5,21 +5,33 @@
   <nav class="admin-nav" aria-label="后台管理导航">
     <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a class="is-active" href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
   </nav>
-  <div class="page-title"><p class="eyebrow">Admin Users</p><h1>用户管理</h1><p>查看平台用户并维护账号状态。</p></div>
+  <div class="page-title"><p class="eyebrow">Admin Users</p><h1>用户管理</h1><p>查看平台用户并维护账号状态和管理员权限。</p></div>
   <div class="admin-table-wrap"><table class="admin-table">
     <thead><tr><th>ID</th><th>用户名</th><th>邮箱</th><th>角色</th><th>信任分</th><th>创建时间</th><th>状态</th><th>操作</th></tr></thead>
     <tbody>{% for user in users %}<tr>
       <td>{{ user.id }}</td><td>{{ user.username }}</td><td>{{ user.email }}</td><td>{{ user.role }}</td><td>{{ user.trust_score }}</td><td>{{ user.created_at.strftime('%Y-%m-%d %H:%M') }}</td><td><span class="admin-status status-{{ user.status }}">{{ user.status }}</span></td>
-      <td>
-        {% if user.id == current_user.id %}
-          <span class="admin-muted">当前管理员，不可封禁</span>
-        {% elif user.status == 'active' %}
-          <form method="post" action="{{ url_for('admin.ban_user', user_id=user.id) }}"><button class="button button-small button-danger" type="submit">封禁</button></form>
-        {% elif user.status == 'banned' %}
-          <form method="post" action="{{ url_for('admin.unban_user', user_id=user.id) }}"><button class="button button-small" type="submit">解封</button></form>
-        {% else %}
-          <span class="admin-muted">当前状态不可操作</span>
-        {% endif %}
+      <td><div class="admin-user-actions">
+        <div class="admin-action-group">
+          {% if user.role == 'user' and user.status == 'active' %}
+            <form method="post" action="{{ url_for('admin.promote_admin', user_id=user.id) }}"><button class="button button-small" type="submit">设为管理员</button></form>
+          {% elif user.role == 'admin' and user.id != current_user.id %}
+            <form method="post" action="{{ url_for('admin.demote_admin', user_id=user.id) }}"><button class="button button-small button-secondary" type="submit">撤销管理员</button></form>
+          {% elif user.role == 'admin' %}
+            <span class="admin-muted">不能撤销自己的管理员权限</span>
+          {% endif %}
+        </div>
+        <div class="admin-action-group">
+          {% if user.id == current_user.id %}
+            <span class="admin-muted">当前管理员，不可封禁</span>
+          {% elif user.status == 'active' %}
+            <form method="post" action="{{ url_for('admin.ban_user', user_id=user.id) }}"><button class="button button-small button-danger" type="submit">封禁</button></form>
+          {% elif user.status == 'banned' %}
+            <form method="post" action="{{ url_for('admin.unban_user', user_id=user.id) }}"><button class="button button-small" type="submit">解封</button></form>
+          {% else %}
+            <span class="admin-muted">当前状态不可操作</span>
+          {% endif %}
+        </div>
+      </div>
       </td>
     </tr>{% else %}<tr><td class="admin-empty" colspan="8">暂无用户。</td></tr>{% endfor %}</tbody>
   </table></div>


### PR DESCRIPTION
## 关联 Issue
Closes #填写 US-16-06 的 Issue 编号

## 本次完成内容
- 管理员用户管理列表显示用户角色
- 管理员可以将普通用户设为管理员
- 管理员可以撤销其他管理员权限
- 管理员不能撤销自己的管理员权限
- 系统不能撤销最后一个管理员
- 被封禁或已注销用户不能被提升为管理员
- 权限变更操作使用 POST
- 权限变更操作写入 AdminLog

## 自测情况
- [x] git diff --check 通过
- [x] python -m compileall app 通过
- [x] app.url_map 可正常输出
- [x] 普通用户可以被设为管理员
- [x] 其他管理员可以被撤销管理员权限
- [x] 不能撤销自己的管理员权限
- [x] 不能撤销最后一个管理员
- [x] 封禁/注销用户不能被提升为管理员
- [x] /admin/logs 可以看到权限变更日志

## 主要修改文件
- app/routes/admin.py
- app/templates/admin_users.html
- app/static/css/style.css

## 需要 Review 的重点
请重点检查权限变更是否全部使用 POST、是否防止撤销自己和最后一个管理员，以及 AdminLog 是否正确记录 role 变化。