### PR TITLE
feat(US-18-01): 优化个人主页内容管理和同好圈退出

### DIFF
--- a/app/routes/circle.py
+++ b/app/routes/circle.py
@@ -547,6 +547,35 @@ def join_circle(circle_id):
     return redirect(url_for("circle.circle_detail", circle_id=circle.id))
 
 
+@circle_bp.route("/circle/<int:circle_id>/leave", methods=["POST"])
+def leave_circle(circle_id):
+    user = _current_user()
+    if user is None:
+        flash("请先登录后再退出同好圈。", "error")
+        return redirect(url_for("auth.login", next=url_for("circle.circle_detail", circle_id=circle_id)))
+
+    circle = Circle.query.get(circle_id)
+    if circle is None:
+        flash("同好圈不存在或已被移除。", "error")
+        return redirect(url_for("circle.circles"))
+
+    member = CircleMember.query.filter_by(
+        circle_id=circle.id,
+        user_id=user.id,
+        status="active",
+    ).first()
+    if member is None:
+        flash("您尚未加入该同好圈。", "info")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    member.status = "inactive"
+    member.updated_at = datetime.utcnow()
+    _refresh_member_count(circle)
+    db.session.commit()
+    flash("已退出同好圈。", "success")
+    return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+
 @circle_bp.route("/circle/<int:circle_id>/post", methods=["GET", "POST"])
 def create_post(circle_id):
     user = _current_user()

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -10,6 +10,7 @@ from app.models import (
     ActivityReview,
     Circle,
     CircleMember,
+    Comment,
     Interaction,
     Post,
     ProfileVisibility,
@@ -132,7 +133,7 @@ def _registration_items(user):
 
 def _circle_items(user):
     rows = _safe_all(
-        CircleMember.query.filter_by(user_id=user.id)
+        CircleMember.query.filter_by(user_id=user.id, status="active")
         .order_by(CircleMember.joined_at.desc())
     )
     return [
@@ -185,14 +186,6 @@ def _circle_interactions(user):
             .order_by(Interaction.created_at.desc())
         )
     ]
-    posts = [
-        {
-            "title": post.circle.name if post.circle else _circle_label(post.circle_id),
-            "action": f"发布帖子：{post.title}",
-            "time": post.created_at,
-        }
-        for post in _safe_all(Post.query.filter_by(user_id=user.id).order_by(Post.created_at.desc()))
-    ]
     user_reviews = [
         {
             "title": review.activity.title if review.activity else _activity_label(review.activity_id),
@@ -204,7 +197,24 @@ def _circle_interactions(user):
             .order_by(UserReview.created_at.desc())
         )
     ]
-    return sorted(circle_actions + posts + user_reviews, key=lambda item: item["time"], reverse=True)
+    return sorted(circle_actions + user_reviews, key=lambda item: item["time"], reverse=True)
+
+
+def _profile_posts(user):
+    return _safe_all(
+        Post.query.filter_by(user_id=user.id)
+        .order_by(Post.created_at.desc())
+    )
+
+
+def _profile_comments(user):
+    return _safe_all(
+        Comment.query.filter(
+            Comment.author_id == user.id,
+            Comment.post_id.isnot(None),
+        )
+        .order_by(Comment.created_at.desc())
+    )
 
 
 @profile_bp.route("/")
@@ -214,6 +224,7 @@ def my_profile():
 
 
 @profile_bp.route("/<int:user_id>")
+@login_required
 def view_profile(user_id):
     user = User.query.get_or_404(user_id)
     display_name = get_user_display_name(user)
@@ -246,7 +257,53 @@ def view_profile(user_id):
         circle_memberships=_circle_items(user) if permissions["circles"] else [],
         activity_interactions=_activity_interactions(user) if permissions["interactions"] else [],
         circle_interactions=_circle_interactions(user) if permissions["interactions"] else [],
+        profile_posts=_profile_posts(user) if is_owner else [],
+        profile_comments=_profile_comments(user) if is_owner else [],
     )
+
+
+@profile_bp.route("/post/<int:post_id>/delete", methods=["POST"])
+@login_required
+def delete_post(post_id):
+    post = Post.query.get(post_id)
+    if post is None:
+        flash("帖子不存在或已被移除。", "error")
+        return redirect(url_for("profile.my_profile"))
+
+    if post.user_id != session["user_id"]:
+        flash("您只能删除自己发布的帖子。", "error")
+        return redirect(url_for("profile.my_profile"))
+
+    if post.status == "deleted":
+        flash("该帖子已经删除。", "info")
+        return redirect(url_for("profile.my_profile"))
+
+    post.status = "deleted"
+    db.session.commit()
+    flash("帖子已删除。", "success")
+    return redirect(url_for("profile.my_profile"))
+
+
+@profile_bp.route("/comment/<int:comment_id>/delete", methods=["POST"])
+@login_required
+def delete_comment(comment_id):
+    comment = Comment.query.get(comment_id)
+    if comment is None:
+        flash("评论不存在或已被移除。", "error")
+        return redirect(url_for("profile.my_profile"))
+
+    if comment.author_id != session["user_id"]:
+        flash("您只能删除自己发布的评论。", "error")
+        return redirect(url_for("profile.my_profile"))
+
+    if comment.status == "deleted":
+        flash("该评论已经删除。", "info")
+        return redirect(url_for("profile.my_profile"))
+
+    comment.status = "deleted"
+    db.session.commit()
+    flash("评论已删除。", "success")
+    return redirect(url_for("profile.my_profile"))
 
 
 @profile_bp.route("/edit", methods=["GET", "POST"])

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2226,7 +2226,8 @@ textarea.form-input {
 
 .admin-status.status-hidden,
 .admin-status.status-banned,
-.admin-status.status-closed {
+.admin-status.status-closed,
+.admin-status.status-deleted {
   background: #f4e4df;
   color: #8b4638;
 }
@@ -2290,6 +2291,32 @@ textarea.form-input {
   background: #f8e8e4;
   color: #8b4638;
   font-weight: 700;
+}
+
+.profile-content-section {
+  margin-top: 24px;
+}
+
+.profile-content-subsection + .profile-content-subsection {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--color-border);
+}
+
+.profile-content-subsection h4 {
+  margin-bottom: 12px;
+}
+
+.profile-content-table {
+  min-width: 760px;
+}
+
+.profile-comment-summary {
+  max-width: 260px;
+}
+
+.circle-inline-form {
+  display: inline;
 }
 
 .account-settings-container {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,7 +16,6 @@
         <li><a href="{{ url_for('circle.circles') }}">同好圈</a></li>
         {% if session.get('user_id') %}
           <li><a href="{{ url_for('profile.my_profile') }}">个人主页</a></li>
-          <li><a href="{{ url_for('auth.account_settings') }}">账号设置</a></li>
           {% if current_user and current_user.role == 'admin' %}
             <li><a href="{{ url_for('admin.admin_dashboard') }}">后台管理</a></li>
           {% endif %}

--- a/app/templates/circle_detail.html
+++ b/app/templates/circle_detail.html
@@ -108,8 +108,11 @@
             {% if current_user %}
                 {% if is_member %}
                 <a class="button" href="{{ url_for('circle.create_post', circle_id=circle.id) }}">发布帖子</a>
+                <form method="POST" action="{{ url_for('circle.leave_circle', circle_id=circle.id) }}" class="circle-inline-form" onsubmit="return confirm('确定退出这个同好圈吗？');">
+                    <button class="button button-danger" type="submit">退出圈子</button>
+                </form>
                 {% else %}
-                <form method="POST" action="{{ url_for('circle.join_circle', circle_id=circle.id) }}" style="display: inline;">
+                <form method="POST" action="{{ url_for('circle.join_circle', circle_id=circle.id) }}" class="circle-inline-form">
                     <button class="button" type="submit">加入圈子</button>
                 </form>
                 <p class="circle-description">加入后可以发帖；未加入时仍可评论、点赞、收藏和转发。</p>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -55,6 +55,7 @@
       {% if is_owner %}
       <div class="registration-action">
         <a class="button" href="{{ url_for('profile.edit_profile') }}">编辑个人资料</a>
+        <a class="button button-secondary" href="{{ url_for('auth.account_settings') }}">账号设置</a>
       </div>
       {% endif %}
     </div>
@@ -88,7 +89,7 @@
       {% if circle_memberships %}
         <div class="card-grid">
           {% for item in circle_memberships %}
-          <a class="activity-card" href="{{ url_for('circle.circles') }}">
+          <a class="activity-card" href="{{ url_for('circle.circle_detail', circle_id=item.id) }}">
             <div class="card-body">
               <h3 class="card-title">{{ item.name }}</h3>
               <div class="card-meta">
@@ -102,6 +103,119 @@
         </div>
       {% else %}
         <p class="rating-empty">暂无加入的同好圈。</p>
+      {% endif %}
+    </div>
+    {% endif %}
+
+    {% if is_owner %}
+    <div class="rating-section profile-content-section">
+      <div class="rating-header"><h3>我的同好圈内容</h3></div>
+      <div class="profile-content-subsection">
+      <h4>我的帖子</h4>
+      {% if profile_posts %}
+      <div class="admin-table-wrap">
+        <table class="admin-table profile-content-table">
+          <thead>
+            <tr>
+              <th>标题</th>
+              <th>所属同好圈</th>
+              <th>发布时间</th>
+              <th>状态</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for post in profile_posts %}
+            <tr>
+              <td>{{ post.title }}</td>
+              <td>{{ post.circle.name if post.circle else '-' }}</td>
+              <td>{{ post.created_at.strftime('%Y-%m-%d %H:%M') if post.created_at else '-' }}</td>
+              <td><span class="admin-status status-{{ post.status }}">{{ post.status }}</span></td>
+              <td>
+                <div class="admin-action-group">
+                  {% if post.circle %}
+                  <a class="button button-small button-secondary" href="{{ url_for('circle.circle_detail', circle_id=post.circle_id, _anchor='post-' ~ post.id) }}">查看</a>
+                  {% endif %}
+                  {% if post.status != 'deleted' %}
+                  <form method="post" action="{{ url_for('profile.delete_post', post_id=post.id) }}" onsubmit="return confirm('确定删除这篇帖子吗？');">
+                    <button class="button button-small button-danger" type="submit">删除</button>
+                  </form>
+                  {% endif %}
+                </div>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="rating-empty">暂未发布帖子。</p>
+      {% endif %}
+      </div>
+
+      <div class="profile-content-subsection">
+      <h4>我的评论</h4>
+      {% if profile_comments %}
+      <div class="admin-table-wrap">
+        <table class="admin-table profile-content-table">
+          <thead>
+            <tr>
+              <th>评论摘要</th>
+              <th>所属帖子 / 同好圈</th>
+              <th>发布时间</th>
+              <th>状态</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for comment in profile_comments %}
+            <tr>
+              <td class="profile-comment-summary">{{ comment.content|trim|truncate(48, True) or '图片评论' }}</td>
+              <td>
+                {% if comment.post %}
+                {{ comment.post.title }} / {{ comment.post.circle.name if comment.post.circle else '-' }}
+                {% else %}
+                -
+                {% endif %}
+              </td>
+              <td>{{ comment.created_at.strftime('%Y-%m-%d %H:%M') if comment.created_at else '-' }}</td>
+              <td><span class="admin-status status-{{ comment.status }}">{{ comment.status }}</span></td>
+              <td>
+                <div class="admin-action-group">
+                  {% if comment.post and comment.post.circle %}
+                  <a class="button button-small button-secondary" href="{{ url_for('circle.circle_detail', circle_id=comment.post.circle_id, _anchor='comment-' ~ comment.id) }}">查看</a>
+                  {% endif %}
+                  {% if comment.status != 'deleted' %}
+                  <form method="post" action="{{ url_for('profile.delete_comment', comment_id=comment.id) }}" onsubmit="return confirm('确定删除这条评论吗？');">
+                    <button class="button button-small button-danger" type="submit">删除</button>
+                  </form>
+                  {% endif %}
+                </div>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="rating-empty">暂未发布评论。</p>
+      {% endif %}
+      </div>
+
+      {% if permissions.interactions %}
+      <div class="profile-content-subsection">
+        <h4>同好圈互动记录</h4>
+        {% if circle_interactions %}
+          {% for item in circle_interactions %}
+            <div class="detail-info-row">
+              <span class="detail-info-label">{{ item.action }}</span>
+              <span class="detail-info-value">{{ item.title }} · {{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</span>
+            </div>
+          {% endfor %}
+        {% else %}
+          <p class="rating-empty">暂无同好圈互动记录。</p>
+        {% endif %}
+      </div>
       {% endif %}
     </div>
     {% endif %}
@@ -121,6 +235,7 @@
       {% endif %}
     </div>
 
+    {% if not is_owner %}
     <div class="rating-section">
       <div class="rating-header"><h3>同好圈互动记录</h3></div>
       {% if circle_interactions %}
@@ -134,6 +249,7 @@
         <p class="rating-empty">暂无同好圈互动记录。</p>
       {% endif %}
     </div>
+    {% endif %}
     {% endif %}
     {% endif %}
   </div>


### PR DESCRIPTION
你是 Gatherly Web 项目的 Flask + Jinja2 开发助手。

当前分支：
feat(US-18-01)

当前任务属于：
[US-18-01] 用户在个人主页管理自己的帖子和评论 的后续优化。

请直接阅读现有代码并修改，不要长篇分析，不要引入 React/Vue/Bootstrap/新依赖，不要重构目录。

本次目标：

1. 整合个人主页中“我的帖子”和“同好圈互动记录”两个板块。
   - 当前页面中“我的帖子”已经展示了帖子表格；
   - “同好圈互动记录”又重复展示了发布帖子记录；
   - 请合并成一个更清晰的个人主页社区内容板块，例如“我的同好圈内容”；
   - 保留帖子查看、删除功能；
   - 如果已有“我的评论”，也放在同一板块下，形成统一的帖子/评论管理区域；
   - 不要重复展示同一条帖子记录。

2. 将普通用户登录后的菜单栏“账号设置”入口整合进个人主页。
   - 普通用户导航栏不再单独显示“账号设置”按钮；
   - 个人主页中增加“账号设置”入口或账号设置卡片；
   - 点击后跳转到现有账号设置页面；
   - 如果项目已有账号设置路由，直接复用，不要新建重复路由；
   - 管理员后台相关账号设置不要受影响。

3. 新增同好圈退出功能。
   - 登录用户如果已经加入某个同好圈，可以退出该同好圈；
   - 退出操作必须使用 POST 请求；
   - 退出按钮需要 confirm 确认提示；
   - 退出成功后 flash 友好提示；
   - 用户未加入该同好圈时，不能报 500，应 flash 提示；
   - 退出后，该同好圈不应继续显示为用户已加入状态；
   - 如果个人主页展示了用户加入的同好圈，也要同步更新。

4. 权限要求：
   - 未登录用户不能访问个人主页和退出同好圈操作；
   - 用户只能管理自己的帖子、评论、加入记录；
   - 不能只靠前端隐藏按钮，后端必须校验登录状态和权限。

允许修改：
- app/routes/profile.py
- app/routes/circle.py
- app/templates/profile.html
- app/templates/base.html
- app/templates/circle.html
- app/templates/circle_detail.html
- app/static/css/style.css
- app/__init__.py，仅在已有蓝图注册确实需要时修改

禁止修改：
- app/routes/auth.py 的注册登录核心逻辑
- app/routes/activity.py 的活动报名和评分逻辑
- app/routes/admin.py 的管理员系统逻辑
- run.py
- requirements.txt
- .env
- 数据库文件
- 不要新增无关功能

实现要求：
1. 自动检查当前项目中同好圈加入关系的真实模型和字段名。
2. 自动检查当前项目中账号设置页面的真实路由名。
3. 自动检查当前个人主页模板中“我的帖子”和“同好圈互动记录”的来源。
4. 个人主页最终不要重复显示同一条帖子。
5. 页面风格保持现有卡片、表格、按钮、标签样式。
6. 删除、退出等危险操作按钮样式要明确。
7. 移动端不要明显错位。

完成后只输出：
1. 修改了哪些文件
2. 新增/修改了哪些路由
3. 如何本地测试
4. 是否满足本次 3 个优化目标