### PR TITLE
feat(US-18-02): 将个人主页筛选调整到板块详情页

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from functools import wraps
 
 from flask import Blueprint, flash, redirect, render_template, request, session, url_for
-from sqlalchemy import func, text
+from sqlalchemy import func, or_, text
 from sqlalchemy.exc import IntegrityError
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -14,6 +14,24 @@ USER_STATUSES = {"active", "banned"}
 ACTIVITY_STATUSES = {"open", "hidden", "closed"}
 CIRCLE_STATUSES = {"active", "hidden"}
 CONTENT_STATUSES = {"published", "hidden"}
+SORT_OPTIONS = {"newest", "oldest"}
+
+
+def _list_filters():
+    return {
+        "q": request.args.get("q", "").strip(),
+        "status": request.args.get("status", "").strip(),
+        "type": request.args.get("type", "").strip(),
+        "sort": request.args.get("sort", "newest").strip()
+        if request.args.get("sort", "newest").strip() in SORT_OPTIONS
+        else "newest",
+    }
+
+
+def _apply_sort(query, created_at, item_id):
+    if request.args.get("sort") == "oldest":
+        return query.order_by(created_at.asc(), item_id.asc())
+    return query.order_by(created_at.desc(), item_id.desc())
 
 
 def get_current_user():
@@ -161,16 +179,61 @@ def admin_dashboard():
 @admin_required
 def admin_logs():
     _ensure_admin_schema()
-    logs = AdminLog.query.order_by(AdminLog.created_at.desc()).limit(100).all()
-    return render_template("admin_logs.html", logs=logs)
+    filters = _list_filters()
+    query = AdminLog.query.join(AdminLog.admin)
+    if filters["q"]:
+        pattern = f"%{filters['q']}%"
+        query = query.filter(
+            or_(
+                User.username.ilike(pattern),
+                AdminLog.action.ilike(pattern),
+                AdminLog.target_type.ilike(pattern),
+                AdminLog.detail.ilike(pattern),
+                AdminLog.ip_address.ilike(pattern),
+            )
+        )
+    if filters["type"]:
+        query = query.filter(AdminLog.target_type == filters["type"])
+    logs = _apply_sort(query, AdminLog.created_at, AdminLog.id).limit(100).all()
+    type_options = [
+        row[0]
+        for row in db.session.query(AdminLog.target_type)
+        .distinct()
+        .order_by(AdminLog.target_type)
+        .all()
+        if row[0]
+    ]
+    return render_template("admin_logs.html", logs=logs, filters=filters, type_options=type_options)
 
 
 @admin_bp.route("/admin/users")
 @admin_required
 def admin_users():
     _ensure_admin_schema()
-    users = User.query.order_by(User.created_at.desc(), User.id.desc()).all()
-    return render_template("admin_users.html", users=users)
+    filters = _list_filters()
+    query = User.query
+    if filters["q"]:
+        pattern = f"%{filters['q']}%"
+        query = query.filter(
+            or_(
+                User.username.ilike(pattern),
+                User.nickname.ilike(pattern),
+                User.email.ilike(pattern),
+                User.interests.ilike(pattern),
+            )
+        )
+    if filters["status"]:
+        query = query.filter(User.status == filters["status"])
+    if filters["type"]:
+        query = query.filter(User.role == filters["type"])
+    users = _apply_sort(query, User.created_at, User.id).all()
+    return render_template(
+        "admin_users.html",
+        users=users,
+        filters=filters,
+        status_options=sorted(USER_STATUSES | {"deleted"}),
+        type_options=["user", "admin"],
+    )
 
 
 def _update_user_ban_status(user_id, new_status):
@@ -278,8 +341,28 @@ def demote_admin(user_id):
 @admin_required
 def admin_activities():
     _ensure_admin_schema()
-    activities = Activity.query.order_by(Activity.created_at.desc(), Activity.id.desc()).all()
-    return render_template("admin_activities.html", activities=activities)
+    filters = _list_filters()
+    query = Activity.query.join(Activity.organizer)
+    if filters["q"]:
+        pattern = f"%{filters['q']}%"
+        query = query.filter(
+            or_(
+                Activity.title.ilike(pattern),
+                Activity.description.ilike(pattern),
+                Activity.location.ilike(pattern),
+                Activity.preparation.ilike(pattern),
+                User.username.ilike(pattern),
+            )
+        )
+    if filters["status"]:
+        query = query.filter(Activity.status == filters["status"])
+    activities = _apply_sort(query, Activity.created_at, Activity.id).all()
+    return render_template(
+        "admin_activities.html",
+        activities=activities,
+        filters=filters,
+        status_options=sorted(ACTIVITY_STATUSES),
+    )
 
 
 @admin_bp.route("/admin/activities/<int:activity_id>/status", methods=["POST"])
@@ -298,15 +381,36 @@ def update_activity_status(activity_id):
 @admin_required
 def admin_circles():
     _ensure_admin_schema()
+    filters = _list_filters()
     circles = (
         db.session.query(Circle, func.count(Post.id).label("post_count"))
         .outerjoin(Post, Post.circle_id == Circle.id)
         .filter(Circle.status != "deleted")
-        .group_by(Circle.id)
-        .order_by(Circle.created_at.desc(), Circle.id.desc())
-        .all()
     )
-    return render_template("admin_circles.html", circles=circles)
+    if filters["q"]:
+        pattern = f"%{filters['q']}%"
+        circles = circles.filter(
+            or_(
+                Circle.name.ilike(pattern),
+                Circle.tag.ilike(pattern),
+                Circle.description.ilike(pattern),
+            )
+        )
+    if filters["status"]:
+        circles = circles.filter(Circle.status == filters["status"])
+    if filters["type"] == "official":
+        circles = circles.filter(Circle.is_system.is_(True))
+    elif filters["type"] == "custom":
+        circles = circles.filter(Circle.is_system.is_(False))
+    circles = circles.group_by(Circle.id)
+    circles = _apply_sort(circles, Circle.created_at, Circle.id).all()
+    return render_template(
+        "admin_circles.html",
+        circles=circles,
+        filters=filters,
+        status_options=sorted(CIRCLE_STATUSES),
+        type_options=["official", "custom"],
+    )
 
 
 @admin_bp.route("/admin/circles/<int:circle_id>/status", methods=["POST"])
@@ -320,8 +424,36 @@ def update_circle_status(circle_id):
 @admin_required
 def admin_posts():
     _ensure_admin_schema()
-    posts = Post.query.order_by(Post.created_at.desc(), Post.id.desc()).all()
-    return render_template("admin_posts.html", posts=posts)
+    filters = _list_filters()
+    query = Post.query.join(Post.user).join(Post.circle)
+    if filters["q"]:
+        pattern = f"%{filters['q']}%"
+        query = query.filter(
+            or_(
+                Post.title.ilike(pattern),
+                Post.content.ilike(pattern),
+                User.username.ilike(pattern),
+                Circle.name.ilike(pattern),
+                Circle.tag.ilike(pattern),
+            )
+        )
+    if filters["status"]:
+        query = query.filter(Post.status == filters["status"])
+    if filters["type"]:
+        query = query.filter(Post.type == filters["type"])
+    posts = _apply_sort(query, Post.created_at, Post.id).all()
+    type_options = [
+        row[0]
+        for row in db.session.query(Post.type).distinct().order_by(Post.type).all()
+        if row[0]
+    ]
+    return render_template(
+        "admin_posts.html",
+        posts=posts,
+        filters=filters,
+        status_options=sorted(CONTENT_STATUSES | {"deleted"}),
+        type_options=type_options,
+    )
 
 
 def _delete_comment_record(comment):
@@ -446,8 +578,34 @@ def update_post_status(post_id):
 @admin_required
 def admin_comments():
     _ensure_admin_schema()
-    comments = Comment.query.order_by(Comment.created_at.desc(), Comment.id.desc()).all()
-    return render_template("admin_comments.html", comments=comments)
+    filters = _list_filters()
+    query = Comment.query.join(Comment.author).outerjoin(Comment.post).outerjoin(Post.circle)
+    if filters["q"]:
+        pattern = f"%{filters['q']}%"
+        query = query.filter(
+            or_(
+                Comment.content.ilike(pattern),
+                User.username.ilike(pattern),
+                Post.title.ilike(pattern),
+                Circle.name.ilike(pattern),
+            )
+        )
+    if filters["status"]:
+        query = query.filter(Comment.status == filters["status"])
+    if filters["type"] == "reply":
+        query = query.filter(Comment.parent_id.isnot(None))
+    elif filters["type"] == "post":
+        query = query.filter(Comment.post_id.isnot(None), Comment.parent_id.is_(None))
+    elif filters["type"] == "activity":
+        query = query.filter(Comment.activity_id.isnot(None), Comment.parent_id.is_(None))
+    comments = _apply_sort(query, Comment.created_at, Comment.id).all()
+    return render_template(
+        "admin_comments.html",
+        comments=comments,
+        filters=filters,
+        status_options=sorted(CONTENT_STATUSES | {"deleted"}),
+        type_options=["post", "activity", "reply"],
+    )
 
 
 @admin_bp.route("/admin/comments/<int:comment_id>/delete", methods=["POST"])

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -1,7 +1,8 @@
 from functools import wraps
+from urllib.parse import urlencode
 
 from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
-from sqlalchemy import text
+from sqlalchemy import or_, text
 from sqlalchemy.exc import IntegrityError, OperationalError
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -25,6 +26,45 @@ profile_bp = Blueprint("profile", __name__, url_prefix="/profile")
 
 PUBLIC_SCOPE = "public"
 PRIVATE_SCOPE = "private"
+SORT_OPTIONS = {"newest", "oldest"}
+
+
+def _section_filters(prefix):
+    return {
+        "q": request.args.get(f"{prefix}_q", "").strip(),
+        "status": request.args.get(f"{prefix}_status", "").strip(),
+        "type": request.args.get(f"{prefix}_type", "").strip(),
+        "sort": request.args.get(f"{prefix}_sort", "newest").strip()
+        if request.args.get(f"{prefix}_sort", "newest").strip() in SORT_OPTIONS
+        else "newest",
+    }
+
+
+def _section_reset_url(prefix, anchor):
+    filtered_args = [
+        (key, value)
+        for key, value in request.args.items(multi=True)
+        if not key.startswith(f"{prefix}_")
+    ]
+    query_string = urlencode(filtered_args)
+    anchor_suffix = f"#{anchor}" if anchor else ""
+    return f"{request.path}{f'?{query_string}' if query_string else ''}{anchor_suffix}"
+
+
+def _ordered_items(items, sort):
+    return sorted(
+        items,
+        key=lambda item: item.get("time") or item.get("created_at"),
+        reverse=sort != "oldest",
+    )
+
+
+def _empty_filters():
+    return {"q": "", "status": "", "type": "", "sort": "newest"}
+
+
+def _preview_items(items, limit=3):
+    return items[:limit]
 
 
 def login_required(view):
@@ -115,12 +155,96 @@ def _circle_label(circle_id):
     return mock_circle["name"] if mock_circle else f"同好圈 #{circle_id}"
 
 
-def _registration_items(user):
+def _matches_text(query, *values):
+    if not query:
+        return True
+    needle = query.casefold()
+    return any(needle in str(value).casefold() for value in values if value)
+
+
+def _registration_matches(activity_id, query):
+    activity = Activity.query.get(activity_id)
+    if activity:
+        return _matches_text(
+            query,
+            activity.title,
+            activity.description,
+            activity.location,
+            activity.preparation,
+            activity.organizer.username if activity.organizer else None,
+        )
+
+    from app.routes.activity import activities
+
+    mock_activity = next((item for item in activities if item.get("id") == activity_id), {})
+    return _matches_text(
+        query,
+        mock_activity.get("title"),
+        mock_activity.get("description"),
+        mock_activity.get("detail"),
+        mock_activity.get("location"),
+        mock_activity.get("category"),
+    )
+
+
+def _membership_matches(circle_id, query):
+    circle = Circle.query.get(circle_id)
+    if circle:
+        return _matches_text(query, circle.name, circle.tag, circle.description)
+
+    from app.routes.circle import mock_circles
+
+    mock_circle = next((item for item in mock_circles if item.get("id") == circle_id), {})
+    return _matches_text(
+        query,
+        mock_circle.get("name"),
+        mock_circle.get("tag"),
+        mock_circle.get("summary"),
+    )
+
+
+def _interaction_type_options(user, target_type, review_type):
+    action_types = [
+        row[0]
+        for row in db.session.query(Interaction.action_type)
+        .filter_by(user_id=user.id, target_type=target_type)
+        .distinct()
+        .order_by(Interaction.action_type)
+        .all()
+        if row[0]
+    ]
+    return action_types + [review_type]
+
+
+def _owner_profile_or_404():
+    user = User.query.get_or_404(session["user_id"])
+    visibility = _get_or_create_visibility(user)
+    return user, visibility
+
+
+def _profile_context(user, visibility, is_owner=True):
+    return {
+        "user": user,
+        "display_name": get_user_display_name(user),
+        "is_owner": is_owner,
+        "visibility": visibility,
+        "permissions": {
+            "interests": is_owner or bool(visibility.show_interests),
+            "activities": is_owner,
+            "circles": is_owner,
+            "interactions": is_owner,
+            "trust_score": _scope_is_visible(visibility.trust_score_scope, is_owner),
+        },
+        "interests": _split_interests(user.interests) if (is_owner or bool(visibility.show_interests)) else [],
+    }
+
+
+def _registration_items(user, filters):
     rows = _safe_all(
         Registration.query.filter_by(user_id=user.id)
         .order_by(Registration.register_time.desc())
     )
-    return [
+    items = [
         {
             "id": row.activity_id,
             "title": _activity_label(row.activity_id),
@@ -129,14 +253,19 @@ def _registration_items(user):
         }
         for row in rows
     ]
+    if filters["q"]:
+        items = [item for item in items if _registration_matches(item["id"], filters["q"])]
+    if filters["status"]:
+        items = [item for item in items if item["status"] == filters["status"]]
+    return _ordered_items(items, filters["sort"])
 
 
-def _circle_items(user):
+def _circle_items(user, filters):
     rows = _safe_all(
         CircleMember.query.filter_by(user_id=user.id, status="active")
         .order_by(CircleMember.joined_at.desc())
     )
-    return [
+    items = [
         {
             "id": row.circle_id,
             "name": _circle_label(row.circle_id),
@@ -146,14 +275,42 @@ def _circle_items(user):
         }
         for row in rows
     ]
+    if filters["q"]:
+        items = [item for item in items if _membership_matches(item["id"], filters["q"])]
+    if filters["status"]:
+        items = [item for item in items if item["status"] == filters["status"]]
+    if filters["type"]:
+        items = [item for item in items if item["role"] == filters["type"]]
+    return _ordered_items(items, filters["sort"])
 
 
-def _activity_interactions(user):
+def _published_activities(user, filters):
+    query = Activity.query.filter(Activity.organizer_id == user.id)
+    if filters["q"]:
+        pattern = f"%{filters['q']}%"
+        query = query.filter(
+            or_(
+                Activity.title.ilike(pattern),
+                Activity.description.ilike(pattern),
+                Activity.location.ilike(pattern),
+                Activity.preparation.ilike(pattern),
+            )
+        )
+    if filters["status"]:
+        query = query.filter(Activity.status == filters["status"])
+    ordering = Activity.created_at.asc() if filters["sort"] == "oldest" else Activity.created_at.desc()
+    return _safe_all(query.order_by(ordering, Activity.id.asc() if filters["sort"] == "oldest" else Activity.id.desc()))
+
+
+def _activity_interactions(user, filters):
     activity_actions = [
         {
+            "id": item.target_id,
             "title": _activity_label(item.target_id),
             "action": item.action_type,
+            "type": item.action_type,
             "time": item.created_at,
+            "url": url_for("activity.activity_detail", activity_id=item.target_id),
         }
         for item in _safe_all(
             Interaction.query.filter_by(user_id=user.id, target_type="activity")
@@ -162,24 +319,40 @@ def _activity_interactions(user):
     ]
     activity_reviews = [
         {
+            "id": review.activity_id,
             "title": review.activity.title if review.activity else _activity_label(review.activity_id),
+            "type": "activity_review",
             "action": f"活动评分 {review.average_score}/5",
             "time": review.created_at,
+            "url": url_for("activity.activity_detail", activity_id=review.activity_id),
         }
         for review in _safe_all(
             ActivityReview.query.filter_by(reviewer_id=user.id)
             .order_by(ActivityReview.created_at.desc())
         )
     ]
-    return sorted(activity_actions + activity_reviews, key=lambda item: item["time"], reverse=True)
+    items = activity_actions + activity_reviews
+    if filters["q"]:
+        needle = filters["q"].casefold()
+        items = [
+            item
+            for item in items
+            if needle in item["title"].casefold() or needle in item["action"].casefold()
+        ]
+    if filters["type"]:
+        items = [item for item in items if item["type"] == filters["type"]]
+    return _ordered_items(items, filters["sort"])
 
 
-def _circle_interactions(user):
+def _circle_interactions(user, filters):
     circle_actions = [
         {
+            "id": item.target_id,
             "title": _circle_label(item.target_id),
             "action": item.action_type,
+            "type": item.action_type,
             "time": item.created_at,
+            "url": url_for("circle.circle_detail", circle_id=item.target_id),
         }
         for item in _safe_all(
             Interaction.query.filter_by(user_id=user.id, target_type="circle")
@@ -188,33 +361,81 @@ def _circle_interactions(user):
     ]
     user_reviews = [
         {
+            "id": review.activity_id,
             "title": review.activity.title if review.activity else _activity_label(review.activity_id),
+            "type": "user_review",
             "action": f"评价活动伙伴 {review.average_score}/5",
             "time": review.created_at,
+            # User reviews currently belong to activities, so the existing
+            # activity detail page is the closest available destination.
+            "url": url_for("activity.activity_detail", activity_id=review.activity_id),
         }
         for review in _safe_all(
             UserReview.query.filter_by(reviewer_id=user.id)
             .order_by(UserReview.created_at.desc())
         )
     ]
-    return sorted(circle_actions + user_reviews, key=lambda item: item["time"], reverse=True)
+    items = circle_actions + user_reviews
+    if filters["q"]:
+        needle = filters["q"].casefold()
+        items = [
+            item
+            for item in items
+            if needle in item["title"].casefold() or needle in item["action"].casefold()
+        ]
+    if filters["type"]:
+        items = [item for item in items if item["type"] == filters["type"]]
+    return _ordered_items(items, filters["sort"])
 
 
-def _profile_posts(user):
-    return _safe_all(
-        Post.query.filter_by(user_id=user.id)
-        .order_by(Post.created_at.desc())
-    )
-
-
-def _profile_comments(user):
-    return _safe_all(
-        Comment.query.filter(
-            Comment.author_id == user.id,
-            Comment.post_id.isnot(None),
+def _profile_posts(user, filters):
+    query = Post.query.join(Post.circle).filter(Post.user_id == user.id)
+    if filters["q"]:
+        pattern = f"%{filters['q']}%"
+        query = query.filter(
+            or_(
+                Post.title.ilike(pattern),
+                Post.content.ilike(pattern),
+                Circle.name.ilike(pattern),
+                Circle.tag.ilike(pattern),
+            )
         )
-        .order_by(Comment.created_at.desc())
+    if filters["status"]:
+        query = query.filter(Post.status == filters["status"])
+    if filters["type"]:
+        query = query.filter(Post.type == filters["type"])
+    ordering = Post.created_at.asc() if filters["sort"] == "oldest" else Post.created_at.desc()
+    return _safe_all(query.order_by(ordering, Post.id.asc() if filters["sort"] == "oldest" else Post.id.desc()))
+
+
+def _profile_comments(user, filters):
+    query = (
+        Comment.query.outerjoin(Comment.post)
+        .outerjoin(Post.circle)
+        .outerjoin(Comment.activity)
+        .filter(Comment.author_id == user.id)
     )
+    if filters["q"]:
+        pattern = f"%{filters['q']}%"
+        query = query.filter(
+            or_(
+                Comment.content.ilike(pattern),
+                Post.title.ilike(pattern),
+                Circle.name.ilike(pattern),
+                Activity.title.ilike(pattern),
+                Activity.location.ilike(pattern),
+            )
+        )
+    if filters["status"]:
+        query = query.filter(Comment.status == filters["status"])
+    if filters["type"] == "reply":
+        query = query.filter(Comment.parent_id.isnot(None))
+    elif filters["type"] == "post":
+        query = query.filter(Comment.post_id.isnot(None), Comment.parent_id.is_(None))
+    elif filters["type"] == "activity":
+        query = query.filter(Comment.activity_id.isnot(None), Comment.parent_id.is_(None))
+    ordering = Comment.created_at.asc() if filters["sort"] == "oldest" else Comment.created_at.desc()
+    return _safe_all(query.order_by(ordering, Comment.id.asc() if filters["sort"] == "oldest" else Comment.id.desc()))
 
 
 @profile_bp.route("/")
@@ -236,29 +457,155 @@ def view_profile(user_id):
 
     if visibility.profile_scope == PRIVATE_SCOPE and not is_owner:
         abort(404)
+    context = _profile_context(user, visibility, is_owner=is_owner)
+    if not is_owner:
+        return render_template("profile.html", **context)
 
-    permissions = {
-        "interests": is_owner or bool(visibility.show_interests),
-        "activities": _scope_is_visible(visibility.activity_scope, is_owner),
-        "circles": _scope_is_visible(visibility.circle_scope, is_owner),
-        "interactions": is_owner or bool(visibility.show_interactions),
-        "trust_score": _scope_is_visible(visibility.trust_score_scope, is_owner),
-    }
+    default_filters = _empty_filters()
+    created_activities = _published_activities(user, default_filters)
+    joined_activities = _registration_items(user, default_filters)
+    circles = _circle_items(user, default_filters)
+    posts = _profile_posts(user, default_filters)
+    comments = _profile_comments(user, default_filters)
+    activity_interactions = _activity_interactions(user, default_filters)
+    circle_interactions = _circle_interactions(user, default_filters)
 
     return render_template(
         "profile.html",
-        user=user,
-        display_name=display_name,
-        is_owner=is_owner,
-        visibility=visibility,
-        permissions=permissions,
-        interests=_split_interests(user.interests) if permissions["interests"] else [],
-        registrations=_registration_items(user) if permissions["activities"] else [],
-        circle_memberships=_circle_items(user) if permissions["circles"] else [],
-        activity_interactions=_activity_interactions(user) if permissions["interactions"] else [],
-        circle_interactions=_circle_interactions(user) if permissions["interactions"] else [],
-        profile_posts=_profile_posts(user) if is_owner else [],
-        profile_comments=_profile_comments(user) if is_owner else [],
+        **context,
+        created_activities_preview=_preview_items(created_activities),
+        created_activities_count=len(created_activities),
+        joined_activities_preview=_preview_items(joined_activities),
+        joined_activities_count=len(joined_activities),
+        circle_memberships_preview=_preview_items(circles),
+        circle_memberships_count=len(circles),
+        profile_posts_preview=_preview_items(posts),
+        profile_posts_count=len(posts),
+        profile_comments_preview=_preview_items(comments),
+        profile_comments_count=len(comments),
+        activity_interactions_preview=_preview_items(activity_interactions),
+        activity_interactions_count=len(activity_interactions),
+        circle_interactions_preview=_preview_items(circle_interactions),
+        circle_interactions_count=len(circle_interactions),
+    )
+
+
+def _render_profile_section(section_key, template_title, heading, items, filter_prefix, status_options, type_options):
+    user, visibility = _owner_profile_or_404()
+    context = _profile_context(user, visibility, is_owner=True)
+    filters = _section_filters(filter_prefix)
+    return render_template(
+        "profile_section.html",
+        **context,
+        section_key=section_key,
+        page_title=template_title,
+        section_heading=heading,
+        items=items(user, filters),
+        filters=filters,
+        filter_prefix=filter_prefix,
+        reset_url=_section_reset_url(filter_prefix, ""),
+        status_options=status_options,
+        type_options=type_options,
+    )
+
+
+@profile_bp.route("/activities/created")
+@login_required
+def created_activities():
+    return _render_profile_section(
+        "created_activity",
+        "我发布的活动",
+        "我发布的活动",
+        _published_activities,
+        "created_activity",
+        ["open", "hidden", "closed"],
+        [],
+    )
+
+
+@profile_bp.route("/activities/joined")
+@login_required
+def joined_activities():
+    return _render_profile_section(
+        "joined_activity",
+        "报名的活动",
+        "报名的活动",
+        _registration_items,
+        "joined_activity",
+        ["registered"],
+        [],
+    )
+
+
+@profile_bp.route("/circles")
+@login_required
+def my_circles():
+    return _render_profile_section(
+        "circle",
+        "加入的同好圈",
+        "加入的同好圈",
+        _circle_items,
+        "circle",
+        ["active"],
+        ["member", "owner"],
+    )
+
+
+@profile_bp.route("/posts")
+@login_required
+def my_posts():
+    return _render_profile_section(
+        "post",
+        "我的帖子",
+        "我的帖子",
+        _profile_posts,
+        "post",
+        ["published", "hidden", "deleted"],
+        ["share"],
+    )
+
+
+@profile_bp.route("/comments")
+@login_required
+def my_comments():
+    return _render_profile_section(
+        "comment",
+        "我的评论",
+        "我的评论",
+        _profile_comments,
+        "comment",
+        ["published", "hidden", "deleted"],
+        ["post", "activity", "reply"],
+    )
+
+
+@profile_bp.route("/interactions/activities")
+@login_required
+def my_activity_interactions():
+    user, _ = _owner_profile_or_404()
+    return _render_profile_section(
+        "activity_interaction",
+        "活动互动记录",
+        "活动互动记录",
+        _activity_interactions,
+        "activity_interaction",
+        [],
+        _interaction_type_options(user, "activity", "activity_review"),
+    )
+
+
+@profile_bp.route("/interactions/circles")
+@login_required
+def my_circle_interactions():
+    user, _ = _owner_profile_or_404()
+    return _render_profile_section(
+        "circle_interaction",
+        "同好圈互动记录",
+        "同好圈互动记录",
+        _circle_interactions,
+        "circle_interaction",
+        [],
+        _interaction_type_options(user, "circle", "user_review"),
     )
 
 
@@ -266,44 +613,46 @@ def view_profile(user_id):
 @login_required
 def delete_post(post_id):
     post = Post.query.get(post_id)
+    fallback_url = request.referrer or url_for("profile.my_posts")
     if post is None:
         flash("帖子不存在或已被移除。", "error")
-        return redirect(url_for("profile.my_profile"))
+        return redirect(fallback_url)
 
     if post.user_id != session["user_id"]:
         flash("您只能删除自己发布的帖子。", "error")
-        return redirect(url_for("profile.my_profile"))
+        return redirect(fallback_url)
 
     if post.status == "deleted":
         flash("该帖子已经删除。", "info")
-        return redirect(url_for("profile.my_profile"))
+        return redirect(fallback_url)
 
     post.status = "deleted"
     db.session.commit()
     flash("帖子已删除。", "success")
-    return redirect(url_for("profile.my_profile"))
+    return redirect(fallback_url)
 
 
 @profile_bp.route("/comment/<int:comment_id>/delete", methods=["POST"])
 @login_required
 def delete_comment(comment_id):
     comment = Comment.query.get(comment_id)
+    fallback_url = request.referrer or url_for("profile.my_comments")
     if comment is None:
         flash("评论不存在或已被移除。", "error")
-        return redirect(url_for("profile.my_profile"))
+        return redirect(fallback_url)
 
     if comment.author_id != session["user_id"]:
         flash("您只能删除自己发布的评论。", "error")
-        return redirect(url_for("profile.my_profile"))
+        return redirect(fallback_url)
 
     if comment.status == "deleted":
         flash("该评论已经删除。", "info")
-        return redirect(url_for("profile.my_profile"))
+        return redirect(fallback_url)
 
     comment.status = "deleted"
     db.session.commit()
     flash("评论已删除。", "success")
-    return redirect(url_for("profile.my_profile"))
+    return redirect(fallback_url)
 
 
 @profile_bp.route("/edit", methods=["GET", "POST"])

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2148,6 +2148,47 @@ textarea.form-input {
   color: var(--color-primary-dark);
 }
 
+.list-filter-card {
+  display: flex;
+  align-items: end;
+  gap: 12px;
+  margin: 0 0 18px;
+  padding: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-surface);
+  box-shadow: 0 8px 20px rgba(34, 34, 34, 0.05);
+}
+
+.list-filter-field {
+  flex: 0 1 160px;
+  min-width: 0;
+}
+
+.list-filter-search {
+  flex: 1 1 280px;
+}
+
+.list-filter-field label {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--color-primary-dark);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.list-filter-field .form-input {
+  width: 100%;
+  min-width: 0;
+}
+
+.list-filter-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+  padding-bottom: 1px;
+}
+
 .admin-panel {
   margin-top: 36px;
 }
@@ -2297,6 +2338,62 @@ textarea.form-input {
   margin-top: 24px;
 }
 
+.profile-overview-grid {
+  display: grid;
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.profile-overview-card {
+  margin-top: 0;
+}
+
+.profile-overview-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.profile-overview-heading h3,
+.profile-overview-heading p {
+  margin-bottom: 0;
+}
+
+.profile-overview-heading p {
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.profile-overview-list {
+  display: grid;
+  gap: 10px;
+}
+
+.profile-overview-item {
+  display: block;
+  padding: 14px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: #fbfaf7;
+}
+
+.profile-overview-item strong,
+.profile-overview-item span {
+  display: block;
+}
+
+.profile-overview-item span {
+  margin-top: 4px;
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.profile-section-panel {
+  margin-top: 0;
+}
+
 .profile-content-subsection + .profile-content-subsection {
   margin-top: 24px;
   padding-top: 20px;
@@ -2373,6 +2470,27 @@ textarea.form-input {
 }
 
 @media (max-width: 720px) {
+  .list-filter-card {
+    align-items: stretch;
+    flex-direction: column;
+    padding: 14px;
+  }
+
+  .list-filter-field,
+  .list-filter-search {
+    flex-basis: auto;
+    width: 100%;
+  }
+
+  .list-filter-actions {
+    flex-wrap: wrap;
+  }
+
+  .profile-overview-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
   .admin-grid {
     grid-template-columns: 1fr;
   }

--- a/app/templates/_list_filters.html
+++ b/app/templates/_list_filters.html
@@ -1,0 +1,50 @@
+{% macro list_filters(endpoint, filters, status_options=(), type_options=(), prefix='', reset_url='', anchor='', show_empty_filters=false) %}
+{% set field_prefix = prefix ~ '_' if prefix else '' %}
+{% set field_id = prefix if prefix else endpoint|replace('.', '-') %}
+<form class="list-filter-card" method="get" action="{{ request.path }}{% if anchor %}#{{ anchor }}{% endif %}">
+  {% if prefix %}
+    {% for key, value in request.args.items() %}
+      {% if not key.startswith(field_prefix) %}
+      <input type="hidden" name="{{ key }}" value="{{ value }}">
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+  <div class="list-filter-field list-filter-search">
+    <label for="{{ field_id }}-q">搜索</label>
+    <input class="form-input" id="{{ field_id }}-q" name="{{ field_prefix }}q" type="search" value="{{ filters.q }}" placeholder="搜索标题、正文、用户名、地点、标签或圈子名">
+  </div>
+  {% if status_options or show_empty_filters %}
+  <div class="list-filter-field">
+    <label for="{{ field_id }}-status">状态</label>
+    <select class="form-input" id="{{ field_id }}-status" name="{{ field_prefix }}status" {% if not status_options %}disabled{% endif %}>
+      {% if status_options %}<option value="">全部状态</option>{% else %}<option value="">无可用状态</option>{% endif %}
+      {% for option in status_options %}
+      <option value="{{ option }}" {% if filters.status == option %}selected{% endif %}>{{ option }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  {% endif %}
+  {% if type_options or show_empty_filters %}
+  <div class="list-filter-field">
+    <label for="{{ field_id }}-type">类型</label>
+    <select class="form-input" id="{{ field_id }}-type" name="{{ field_prefix }}type" {% if not type_options %}disabled{% endif %}>
+      {% if type_options %}<option value="">全部类型</option>{% else %}<option value="">无可用类型</option>{% endif %}
+      {% for option in type_options %}
+      <option value="{{ option }}" {% if filters.type == option %}selected{% endif %}>{{ option }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  {% endif %}
+  <div class="list-filter-field">
+    <label for="{{ field_id }}-sort">排序</label>
+    <select class="form-input" id="{{ field_id }}-sort" name="{{ field_prefix }}sort">
+      <option value="newest" {% if filters.sort == 'newest' %}selected{% endif %}>最新优先</option>
+      <option value="oldest" {% if filters.sort == 'oldest' %}selected{% endif %}>最早优先</option>
+    </select>
+  </div>
+  <div class="list-filter-actions">
+    <button class="button button-small" type="submit">筛选</button>
+    <a class="button button-small button-secondary" href="{{ reset_url or request.path }}">重置</a>
+  </div>
+</form>
+{% endmacro %}

--- a/app/templates/admin_activities.html
+++ b/app/templates/admin_activities.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_list_filters.html" import list_filters %}
 {% block title %}活动管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
@@ -6,6 +7,7 @@
     <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a class="is-active" href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Activities</p><h1>活动管理</h1><p>查看活动并维护 open、hidden 或 closed 状态。</p></div>
+  {{ list_filters('admin.admin_activities', filters, status_options) }}
   <div class="admin-table-wrap"><table class="admin-table">
     <thead><tr><th>ID</th><th>标题</th><th>组织者</th><th>地点</th><th>开始时间</th><th>状态</th><th>操作</th></tr></thead>
     <tbody>{% for activity in activities %}<tr>

--- a/app/templates/admin_circles.html
+++ b/app/templates/admin_circles.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_list_filters.html" import list_filters %}
 {% block title %}同好圈管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
@@ -6,6 +7,7 @@
     <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a class="is-active" href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Circles</p><h1>同好圈管理</h1><p>查看全部同好圈，并隐藏、恢复显示或删除内容。</p></div>
+  {{ list_filters('admin.admin_circles', filters, status_options, type_options) }}
   <div class="admin-table-wrap"><table class="admin-table">
     <thead><tr><th>ID</th><th>名称</th><th>简介摘要</th><th>创建时间</th><th>帖子数</th><th>状态</th><th>操作</th></tr></thead>
     <tbody>{% for circle, post_count in circles %}<tr>

--- a/app/templates/admin_comments.html
+++ b/app/templates/admin_comments.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_list_filters.html" import list_filters %}
 {% block title %}评论管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
@@ -6,6 +7,7 @@
     <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a class="is-active" href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Comments</p><h1>评论管理</h1><p>查看用户发布的评论和回复，并删除违规或不适当的内容。</p></div>
+  {{ list_filters('admin.admin_comments', filters, status_options, type_options) }}
   <div class="admin-table-wrap"><table class="admin-table">
     <thead><tr><th>ID</th><th>评论内容摘要</th><th>作者</th><th>所属内容</th><th>状态</th><th>发布时间</th><th>操作</th></tr></thead>
     <tbody>{% for comment in comments %}<tr>

--- a/app/templates/admin_logs.html
+++ b/app/templates/admin_logs.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_list_filters.html" import list_filters %}
 
 {% block title %}操作日志 - Gatherly{% endblock %}
 
@@ -22,6 +23,7 @@
       <p>查看最近 100 条管理员操作记录。</p>
     </div>
 
+    {{ list_filters('admin.admin_logs', filters, (), type_options) }}
     <div class="admin-table-wrap">
       <table class="admin-table">
         <thead><tr><th>时间</th><th>管理员</th><th>操作</th><th>对象</th><th>详情</th><th>IP</th></tr></thead>

--- a/app/templates/admin_posts.html
+++ b/app/templates/admin_posts.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_list_filters.html" import list_filters %}
 {% block title %}帖子管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
@@ -6,6 +7,7 @@
     <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a class="is-active" href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Posts</p><h1>帖子管理</h1><p>查看用户发布的帖子，并删除违规或不适当的内容。</p></div>
+  {{ list_filters('admin.admin_posts', filters, status_options, type_options) }}
   <div class="admin-table-wrap"><table class="admin-table">
     <thead><tr><th>ID</th><th>标题</th><th>作者</th><th>所属圈子</th><th>状态</th><th>发布时间</th><th>操作</th></tr></thead>
     <tbody>{% for post in posts %}<tr>

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_list_filters.html" import list_filters %}
 {% block title %}用户管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
@@ -6,6 +7,7 @@
     <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a class="is-active" href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Users</p><h1>用户管理</h1><p>查看平台用户并维护账号状态和管理员权限。</p></div>
+  {{ list_filters('admin.admin_users', filters, status_options, type_options) }}
   <div class="admin-table-wrap"><table class="admin-table">
     <thead><tr><th>ID</th><th>用户名</th><th>邮箱</th><th>角色</th><th>信任分</th><th>创建时间</th><th>状态</th><th>操作</th></tr></thead>
     <tbody>{% for user in users %}<tr>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -37,7 +37,7 @@
         </span>
       </div>
       <div class="detail-info-row">
-        <span class="detail-info-label">账户状态</span>
+        <span class="detail-info-label">账号角色</span>
         <span class="detail-info-value"><span class="status-badge status-open">{{ user.role }}</span></span>
       </div>
       {% if permissions.interests %}
@@ -60,196 +60,177 @@
       {% endif %}
     </div>
 
-    {% if permissions.activities %}
-    <div class="rating-section">
-      <div class="rating-header"><h3>报名的活动</h3></div>
-      {% if registrations %}
-        <div class="card-grid">
-          {% for item in registrations %}
-          <a class="activity-card" href="{{ url_for('activity.activity_detail', activity_id=item.id) }}">
-            <div class="card-body">
-              <h3 class="card-title">{{ item.title }}</h3>
-              <div class="card-meta">
-                <p>状态：{{ item.status }}</p>
-                <p>报名时间：{{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</p>
-              </div>
-            </div>
-          </a>
-          {% endfor %}
-        </div>
-      {% else %}
-        <p class="rating-empty">暂无报名活动。</p>
-      {% endif %}
-    </div>
-    {% endif %}
-
-    {% if permissions.circles %}
-    <div class="rating-section">
-      <div class="rating-header"><h3>加入的同好圈</h3></div>
-      {% if circle_memberships %}
-        <div class="card-grid">
-          {% for item in circle_memberships %}
-          <a class="activity-card" href="{{ url_for('circle.circle_detail', circle_id=item.id) }}">
-            <div class="card-body">
-              <h3 class="card-title">{{ item.name }}</h3>
-              <div class="card-meta">
-                <p>身份：{{ item.role }}</p>
-                <p>状态：{{ item.status }}</p>
-                <p>加入时间：{{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</p>
-              </div>
-            </div>
-          </a>
-          {% endfor %}
-        </div>
-      {% else %}
-        <p class="rating-empty">暂无加入的同好圈。</p>
-      {% endif %}
-    </div>
-    {% endif %}
-
     {% if is_owner %}
-    <div class="rating-section profile-content-section">
-      <div class="rating-header"><h3>我的同好圈内容</h3></div>
-      <div class="profile-content-subsection">
-      <h4>我的帖子</h4>
-      {% if profile_posts %}
-      <div class="admin-table-wrap">
-        <table class="admin-table profile-content-table">
-          <thead>
-            <tr>
-              <th>标题</th>
-              <th>所属同好圈</th>
-              <th>发布时间</th>
-              <th>状态</th>
-              <th>操作</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for post in profile_posts %}
-            <tr>
-              <td>{{ post.title }}</td>
-              <td>{{ post.circle.name if post.circle else '-' }}</td>
-              <td>{{ post.created_at.strftime('%Y-%m-%d %H:%M') if post.created_at else '-' }}</td>
-              <td><span class="admin-status status-{{ post.status }}">{{ post.status }}</span></td>
-              <td>
-                <div class="admin-action-group">
-                  {% if post.circle %}
-                  <a class="button button-small button-secondary" href="{{ url_for('circle.circle_detail', circle_id=post.circle_id, _anchor='post-' ~ post.id) }}">查看</a>
-                  {% endif %}
-                  {% if post.status != 'deleted' %}
-                  <form method="post" action="{{ url_for('profile.delete_post', post_id=post.id) }}" onsubmit="return confirm('确定删除这篇帖子吗？');">
-                    <button class="button button-small button-danger" type="submit">删除</button>
-                  </form>
-                  {% endif %}
+    <div class="profile-overview-grid">
+      <section class="rating-section profile-overview-card">
+        <div class="profile-overview-heading">
+          <div>
+            <h3>我发布的活动</h3>
+            <p>{{ created_activities_count }} 条</p>
+          </div>
+          <a class="button button-small" href="{{ url_for('profile.created_activities') }}">查看全部</a>
+        </div>
+        {% if created_activities_preview %}
+          <div class="card-grid">
+            {% for activity in created_activities_preview %}
+            <a class="activity-card" href="{{ url_for('activity.activity_detail', activity_id=activity.id) }}">
+              <div class="card-body">
+                <h4 class="card-title">{{ activity.title }}</h4>
+                <div class="card-meta">
+                  <p>地点：{{ activity.location or '-' }}</p>
+                  <p>状态：{{ activity.status }}</p>
                 </div>
-              </td>
-            </tr>
+              </div>
+            </a>
             {% endfor %}
-          </tbody>
-        </table>
-      </div>
-      {% else %}
-      <p class="rating-empty">暂未发布帖子。</p>
-      {% endif %}
-      </div>
+          </div>
+        {% else %}
+          <p class="rating-empty">暂无已发布活动。</p>
+        {% endif %}
+      </section>
 
-      <div class="profile-content-subsection">
-      <h4>我的评论</h4>
-      {% if profile_comments %}
-      <div class="admin-table-wrap">
-        <table class="admin-table profile-content-table">
-          <thead>
-            <tr>
-              <th>评论摘要</th>
-              <th>所属帖子 / 同好圈</th>
-              <th>发布时间</th>
-              <th>状态</th>
-              <th>操作</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for comment in profile_comments %}
-            <tr>
-              <td class="profile-comment-summary">{{ comment.content|trim|truncate(48, True) or '图片评论' }}</td>
-              <td>
-                {% if comment.post %}
-                {{ comment.post.title }} / {{ comment.post.circle.name if comment.post.circle else '-' }}
-                {% else %}
-                -
-                {% endif %}
-              </td>
-              <td>{{ comment.created_at.strftime('%Y-%m-%d %H:%M') if comment.created_at else '-' }}</td>
-              <td><span class="admin-status status-{{ comment.status }}">{{ comment.status }}</span></td>
-              <td>
-                <div class="admin-action-group">
-                  {% if comment.post and comment.post.circle %}
-                  <a class="button button-small button-secondary" href="{{ url_for('circle.circle_detail', circle_id=comment.post.circle_id, _anchor='comment-' ~ comment.id) }}">查看</a>
-                  {% endif %}
-                  {% if comment.status != 'deleted' %}
-                  <form method="post" action="{{ url_for('profile.delete_comment', comment_id=comment.id) }}" onsubmit="return confirm('确定删除这条评论吗？');">
-                    <button class="button button-small button-danger" type="submit">删除</button>
-                  </form>
-                  {% endif %}
+      <section class="rating-section profile-overview-card">
+        <div class="profile-overview-heading">
+          <div>
+            <h3>报名的活动</h3>
+            <p>{{ joined_activities_count }} 条</p>
+          </div>
+          <a class="button button-small" href="{{ url_for('profile.joined_activities') }}">查看全部</a>
+        </div>
+        {% if joined_activities_preview %}
+          <div class="card-grid">
+            {% for item in joined_activities_preview %}
+            <a class="activity-card" href="{{ url_for('activity.activity_detail', activity_id=item.id) }}">
+              <div class="card-body">
+                <h4 class="card-title">{{ item.title }}</h4>
+                <div class="card-meta">
+                  <p>状态：{{ item.status }}</p>
+                  <p>报名时间：{{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</p>
                 </div>
-              </td>
-            </tr>
+              </div>
+            </a>
             {% endfor %}
-          </tbody>
-        </table>
-      </div>
-      {% else %}
-      <p class="rating-empty">暂未发布评论。</p>
-      {% endif %}
-      </div>
+          </div>
+        {% else %}
+          <p class="rating-empty">暂无报名活动。</p>
+        {% endif %}
+      </section>
 
-      {% if permissions.interactions %}
-      <div class="profile-content-subsection">
-        <h4>同好圈互动记录</h4>
-        {% if circle_interactions %}
-          {% for item in circle_interactions %}
-            <div class="detail-info-row">
-              <span class="detail-info-label">{{ item.action }}</span>
-              <span class="detail-info-value">{{ item.title }} · {{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</span>
-            </div>
-          {% endfor %}
+      <section class="rating-section profile-overview-card">
+        <div class="profile-overview-heading">
+          <div>
+            <h3>加入的同好圈</h3>
+            <p>{{ circle_memberships_count }} 条</p>
+          </div>
+          <a class="button button-small" href="{{ url_for('profile.my_circles') }}">查看全部</a>
+        </div>
+        {% if circle_memberships_preview %}
+          <div class="card-grid">
+            {% for item in circle_memberships_preview %}
+            <a class="activity-card" href="{{ url_for('circle.circle_detail', circle_id=item.id) }}">
+              <div class="card-body">
+                <h4 class="card-title">{{ item.name }}</h4>
+                <div class="card-meta">
+                  <p>身份：{{ item.role }}</p>
+                  <p>加入时间：{{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</p>
+                </div>
+              </div>
+            </a>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="rating-empty">暂无加入的同好圈。</p>
+        {% endif %}
+      </section>
+
+      <section class="rating-section profile-overview-card">
+        <div class="profile-overview-heading">
+          <div>
+            <h3>我的帖子</h3>
+            <p>{{ profile_posts_count }} 条</p>
+          </div>
+          <a class="button button-small" href="{{ url_for('profile.my_posts') }}">管理</a>
+        </div>
+        {% if profile_posts_preview %}
+          <div class="profile-overview-list">
+            {% for post in profile_posts_preview %}
+            <a class="profile-overview-item" href="{{ url_for('circle.circle_detail', circle_id=post.circle_id, _anchor='post-' ~ post.id) }}">
+              <strong>{{ post.title }}</strong>
+              <span>{{ post.circle.name if post.circle else '-' }} · {{ post.created_at.strftime('%Y-%m-%d %H:%M') if post.created_at else '-' }}</span>
+            </a>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="rating-empty">暂无帖子。</p>
+        {% endif %}
+      </section>
+
+      <section class="rating-section profile-overview-card">
+        <div class="profile-overview-heading">
+          <div>
+            <h3>我的评论</h3>
+            <p>{{ profile_comments_count }} 条</p>
+          </div>
+          <a class="button button-small" href="{{ url_for('profile.my_comments') }}">管理</a>
+        </div>
+        {% if profile_comments_preview %}
+          <div class="profile-overview-list">
+            {% for comment in profile_comments_preview %}
+            <a class="profile-overview-item" href="{% if comment.post and comment.post.circle %}{{ url_for('circle.circle_detail', circle_id=comment.post.circle_id, _anchor='comment-' ~ comment.id) }}{% elif comment.activity %}{{ url_for('activity.activity_detail', activity_id=comment.activity_id, _anchor='comment-' ~ comment.id) }}{% else %}#{% endif %}">
+              <strong>{{ comment.content|trim|truncate(48, True) or '图片评论' }}</strong>
+              <span>{{ comment.created_at.strftime('%Y-%m-%d %H:%M') if comment.created_at else '-' }}</span>
+            </a>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="rating-empty">暂无评论。</p>
+        {% endif %}
+      </section>
+
+      <section class="rating-section profile-overview-card">
+        <div class="profile-overview-heading">
+          <div>
+            <h3>活动互动记录</h3>
+            <p>{{ activity_interactions_count }} 条</p>
+          </div>
+          <a class="button button-small" href="{{ url_for('profile.my_activity_interactions') }}">查看全部</a>
+        </div>
+        {% if activity_interactions_preview %}
+          <div class="profile-overview-list">
+            {% for item in activity_interactions_preview %}
+            <a class="profile-overview-item" href="{{ item.url }}">
+              <strong>{{ item.title }}</strong>
+              <span>{{ item.action }} · {{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</span>
+            </a>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="rating-empty">暂无活动互动记录。</p>
+        {% endif %}
+      </section>
+
+      <section class="rating-section profile-overview-card">
+        <div class="profile-overview-heading">
+          <div>
+            <h3>同好圈互动记录</h3>
+            <p>{{ circle_interactions_count }} 条</p>
+          </div>
+          <a class="button button-small" href="{{ url_for('profile.my_circle_interactions') }}">查看全部</a>
+        </div>
+        {% if circle_interactions_preview %}
+          <div class="profile-overview-list">
+            {% for item in circle_interactions_preview %}
+            <a class="profile-overview-item" href="{{ item.url }}">
+              <strong>{{ item.title }}</strong>
+              <span>{{ item.action }} · {{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</span>
+            </a>
+            {% endfor %}
+          </div>
         {% else %}
           <p class="rating-empty">暂无同好圈互动记录。</p>
         {% endif %}
-      </div>
-      {% endif %}
+      </section>
     </div>
-    {% endif %}
-
-    {% if permissions.interactions %}
-    <div class="rating-section">
-      <div class="rating-header"><h3>活动互动记录</h3></div>
-      {% if activity_interactions %}
-        {% for item in activity_interactions %}
-          <div class="detail-info-row">
-            <span class="detail-info-label">{{ item.action }}</span>
-            <span class="detail-info-value">{{ item.title }} · {{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</span>
-          </div>
-        {% endfor %}
-      {% else %}
-        <p class="rating-empty">暂无活动互动记录。</p>
-      {% endif %}
-    </div>
-
-    {% if not is_owner %}
-    <div class="rating-section">
-      <div class="rating-header"><h3>同好圈互动记录</h3></div>
-      {% if circle_interactions %}
-        {% for item in circle_interactions %}
-          <div class="detail-info-row">
-            <span class="detail-info-label">{{ item.action }}</span>
-            <span class="detail-info-value">{{ item.title }} · {{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</span>
-          </div>
-        {% endfor %}
-      {% else %}
-        <p class="rating-empty">暂无同好圈互动记录。</p>
-      {% endif %}
-    </div>
-    {% endif %}
     {% endif %}
     {% endif %}
   </div>

--- a/app/templates/profile_section.html
+++ b/app/templates/profile_section.html
@@ -1,0 +1,160 @@
+{% extends "base.html" %}
+{% from "_list_filters.html" import list_filters %}
+
+{% block title %}{{ page_title }} - Gatherly{% endblock %}
+
+{% block content %}
+<section class="section">
+  <div class="container">
+    <a class="back-link" href="{{ url_for('profile.my_profile') }}">返回个人主页</a>
+    <div class="page-title">
+      <p class="eyebrow">Profile Section</p>
+      <h1>{{ section_heading }}</h1>
+    </div>
+
+    {{ list_filters('profile.my_profile', filters, status_options, type_options, filter_prefix, reset_url, '', true) }}
+
+    <div class="rating-section profile-section-panel">
+      {% if section_key in ['created_activity', 'joined_activity', 'circle'] %}
+        {% if items %}
+        <div class="card-grid">
+          {% for item in items %}
+          {% if section_key == 'circle' %}
+          <a class="activity-card" href="{{ url_for('circle.circle_detail', circle_id=item.id) }}">
+            <div class="card-body">
+              <h3 class="card-title">{{ item.name }}</h3>
+              <div class="card-meta">
+                <p>身份：{{ item.role }}</p>
+                <p>状态：{{ item.status }}</p>
+                <p>加入时间：{{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</p>
+              </div>
+            </div>
+          </a>
+          {% else %}
+          <a class="activity-card" href="{{ url_for('activity.activity_detail', activity_id=item.id) }}">
+            <div class="card-body">
+              <h3 class="card-title">{{ item.title }}</h3>
+              <div class="card-meta">
+                {% if section_key == 'created_activity' %}
+                <p>地点：{{ item.location or '-' }}</p>
+                <p>状态：{{ item.status }}</p>
+                <p>发布时间：{{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}</p>
+                {% else %}
+                <p>状态：{{ item.status }}</p>
+                <p>报名时间：{{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</p>
+                {% endif %}
+              </div>
+            </div>
+          </a>
+          {% endif %}
+          {% endfor %}
+        </div>
+        {% else %}
+        <p class="rating-empty">当前筛选条件下暂无内容。</p>
+        {% endif %}
+      {% elif section_key == 'post' %}
+        {% if items %}
+        <div class="admin-table-wrap">
+          <table class="admin-table profile-content-table">
+            <thead>
+              <tr>
+                <th>标题</th>
+                <th>所属同好圈</th>
+                <th>发布时间</th>
+                <th>状态</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for post in items %}
+              <tr>
+                <td>{% if post.circle %}<a href="{{ url_for('circle.circle_detail', circle_id=post.circle_id, _anchor='post-' ~ post.id) }}">{{ post.title }}</a>{% else %}{{ post.title }}{% endif %}</td>
+                <td>{{ post.circle.name if post.circle else '-' }}</td>
+                <td>{{ post.created_at.strftime('%Y-%m-%d %H:%M') if post.created_at else '-' }}</td>
+                <td><span class="admin-status status-{{ post.status }}">{{ post.status }}</span></td>
+                <td>
+                  <div class="admin-action-group">
+                    {% if post.circle %}
+                    <a class="button button-small button-secondary" href="{{ url_for('circle.circle_detail', circle_id=post.circle_id, _anchor='post-' ~ post.id) }}">查看</a>
+                    {% endif %}
+                    {% if post.status != 'deleted' %}
+                    <form method="post" action="{{ url_for('profile.delete_post', post_id=post.id) }}" onsubmit="return confirm('确定删除这篇帖子吗？');">
+                      <button class="button button-small button-danger" type="submit">删除</button>
+                    </form>
+                    {% endif %}
+                  </div>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% else %}
+        <p class="rating-empty">当前筛选条件下暂无帖子。</p>
+        {% endif %}
+      {% elif section_key == 'comment' %}
+        {% if items %}
+        <div class="admin-table-wrap">
+          <table class="admin-table profile-content-table">
+            <thead>
+              <tr>
+                <th>评论摘要</th>
+                <th>所属内容</th>
+                <th>发布时间</th>
+                <th>状态</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for comment in items %}
+              <tr>
+                <td class="profile-comment-summary">{% if comment.post and comment.post.circle %}<a href="{{ url_for('circle.circle_detail', circle_id=comment.post.circle_id, _anchor='comment-' ~ comment.id) }}">{{ comment.content|trim|truncate(48, True) or '图片评论' }}</a>{% elif comment.activity %}<a href="{{ url_for('activity.activity_detail', activity_id=comment.activity_id, _anchor='comment-' ~ comment.id) }}">{{ comment.content|trim|truncate(48, True) or '图片评论' }}</a>{% else %}{{ comment.content|trim|truncate(48, True) or '图片评论' }}{% endif %}</td>
+                <td>
+                  {% if comment.post %}
+                  {{ comment.post.title }} / {{ comment.post.circle.name if comment.post.circle else '-' }}
+                  {% elif comment.activity %}
+                  {{ comment.activity.title }}
+                  {% else %}
+                  -
+                  {% endif %}
+                </td>
+                <td>{{ comment.created_at.strftime('%Y-%m-%d %H:%M') if comment.created_at else '-' }}</td>
+                <td><span class="admin-status status-{{ comment.status }}">{{ comment.status }}</span></td>
+                <td>
+                  <div class="admin-action-group">
+                    {% if comment.post and comment.post.circle %}
+                    <a class="button button-small button-secondary" href="{{ url_for('circle.circle_detail', circle_id=comment.post.circle_id, _anchor='comment-' ~ comment.id) }}">查看</a>
+                    {% elif comment.activity %}
+                    <a class="button button-small button-secondary" href="{{ url_for('activity.activity_detail', activity_id=comment.activity_id, _anchor='comment-' ~ comment.id) }}">查看</a>
+                    {% endif %}
+                    {% if comment.status != 'deleted' %}
+                    <form method="post" action="{{ url_for('profile.delete_comment', comment_id=comment.id) }}" onsubmit="return confirm('确定删除这条评论吗？');">
+                      <button class="button button-small button-danger" type="submit">删除</button>
+                    </form>
+                    {% endif %}
+                  </div>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% else %}
+        <p class="rating-empty">当前筛选条件下暂无评论。</p>
+        {% endif %}
+      {% else %}
+        {% if items %}
+          {% for item in items %}
+          <div class="detail-info-row">
+            <span class="detail-info-label">{{ item.action }}</span>
+            <span class="detail-info-value"><a href="{{ item.url }}">{{ item.title }}</a> · {{ item.time.strftime('%Y-%m-%d %H:%M') if item.time else '-' }}</span>
+          </div>
+          {% endfor %}
+        {% else %}
+        <p class="rating-empty">当前筛选条件下暂无互动记录。</p>
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## 关联 Issue
Closes #对应US-18-02的Issue编号

## 本次完成内容
- 个人主页总览页只保留各内容板块的基本预览和入口
- 将搜索筛选面板移动到各板块详情页
- 支持发布活动、报名活动、同好圈、帖子、评论等板块独立筛选
- 每个板块内容支持点击跳转到对应详情页

## 自测情况
- [x] python -m compileall app 通过
- [x] git diff --check 通过
- [x] 个人主页总览页不再显示筛选栏
- [x] 进入具体板块详情页后才显示筛选栏
- [x] 普通用户只能查看自己的内容