### PR TITLE
feat(US-18-03): 增加个人简介和兴趣标签编辑

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -14,6 +14,7 @@ class User(db.Model):
     email = db.Column(db.String(120), unique=True, nullable=False)
     password = db.Column(db.String(255), nullable=False)
     avatar = db.Column(db.String(255))
+    bio = db.Column(db.Text)
     interests = db.Column(db.Text)
     role = db.Column(db.String(20), default="user", nullable=False)
     trust_score = db.Column(db.Integer, default=100, nullable=False)
@@ -63,8 +64,15 @@ def ensure_user_account_schema():
 
     rows = db.session.execute(text('PRAGMA table_info("user")')).fetchall()
     existing_columns = {row[1] for row in rows}
+    statements = []
     if rows and "deleted_at" not in existing_columns:
-        db.session.execute(text('ALTER TABLE "user" ADD COLUMN deleted_at DATETIME'))
+        statements.append('ALTER TABLE "user" ADD COLUMN deleted_at DATETIME')
+    if rows and "bio" not in existing_columns:
+        statements.append('ALTER TABLE "user" ADD COLUMN bio TEXT')
+
+    for statement in statements:
+        db.session.execute(text(statement))
+    if statements:
         db.session.commit()
 
 

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -27,6 +27,8 @@ profile_bp = Blueprint("profile", __name__, url_prefix="/profile")
 PUBLIC_SCOPE = "public"
 PRIVATE_SCOPE = "private"
 SORT_OPTIONS = {"newest", "oldest"}
+BIO_MAX_LENGTH = 300
+INTERESTS_MAX_LENGTH = 500
 
 
 def _section_filters(prefix):
@@ -123,6 +125,10 @@ def _split_interests(interests):
         return []
     normalized = interests.replace("，", ",")
     return [item.strip() for item in normalized.split(",") if item.strip()]
+
+
+def _normalize_interests(interests):
+    return ", ".join(dict.fromkeys(_split_interests(interests)))
 
 
 def _safe_all(query):
@@ -664,10 +670,30 @@ def edit_profile():
     if request.method == "POST":
         form_type = request.form.get("form_type")
         if form_type == "profile":
-            user.nickname = request.form.get("nickname", "").strip() or user.username
-            user.avatar = request.form.get("avatar", "").strip() or None
-            user.interests = request.form.get("interests", "").strip() or None
-            user.email = request.form.get("email", "").strip() or user.email
+            nickname = request.form.get("nickname", "").strip() or user.username
+            email = request.form.get("email", "").strip()
+            avatar = request.form.get("avatar", "").strip() or None
+            bio = request.form.get("bio", "").strip() or None
+            interests = _normalize_interests(request.form.get("interests", "")) or None
+
+            if len(nickname) > 80:
+                flash("昵称不能超过 80 个字符。", "error")
+                return render_template("edit_profile.html", user=user, visibility=visibility)
+            if not email:
+                flash("邮箱不能为空。", "error")
+                return render_template("edit_profile.html", user=user, visibility=visibility)
+            if len(email) > 120:
+                flash("邮箱不能超过 120 个字符。", "error")
+                return render_template("edit_profile.html", user=user, visibility=visibility)
+            if avatar and len(avatar) > 255:
+                flash("头像 URL 不能超过 255 个字符。", "error")
+                return render_template("edit_profile.html", user=user, visibility=visibility)
+            if bio and len(bio) > BIO_MAX_LENGTH:
+                flash(f"个人简介不能超过 {BIO_MAX_LENGTH} 个字符。", "error")
+                return render_template("edit_profile.html", user=user, visibility=visibility)
+            if interests and len(interests) > INTERESTS_MAX_LENGTH:
+                flash(f"兴趣标签总长度不能超过 {INTERESTS_MAX_LENGTH} 个字符。", "error")
+                return render_template("edit_profile.html", user=user, visibility=visibility)
 
             current_password = request.form.get("current_password", "")
             new_password = request.form.get("new_password", "")
@@ -683,6 +709,12 @@ def edit_profile():
                     flash("新密码至少需要 6 个字符。", "error")
                     return render_template("edit_profile.html", user=user, visibility=visibility)
                 user.password = generate_password_hash(new_password)
+
+            user.nickname = nickname
+            user.email = email
+            user.avatar = avatar
+            user.bio = bio
+            user.interests = interests
 
             try:
                 db.session.commit()

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -471,6 +471,15 @@ img {
   gap: 8px;
 }
 
+.tag-group .tag {
+  margin-right: 0;
+}
+
+.profile-bio {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .meta-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/app/templates/edit_profile.html
+++ b/app/templates/edit_profile.html
@@ -26,8 +26,13 @@
         <input class="form-input" id="avatar" name="avatar" value="{{ user.avatar or '' }}" maxlength="255">
       </div>
       <div class="form-group">
+        <label class="form-label" for="bio">个人简介</label>
+        <textarea class="form-input" id="bio" name="bio" rows="5" maxlength="300" placeholder="简单介绍一下自己、常参加的活动或希望认识的伙伴。">{{ user.bio or '' }}</textarea>
+        <p class="form-hint">最多 300 个字符。</p>
+      </div>
+      <div class="form-group">
         <label class="form-label" for="interests">兴趣标签</label>
-        <input class="form-input" id="interests" name="interests" value="{{ user.interests or '' }}" placeholder="摄影, 露营, 桌游">
+        <input class="form-input" id="interests" name="interests" value="{{ user.interests or '' }}" maxlength="500" placeholder="摄影, 露营, 桌游">
         <p class="form-hint">多个标签用逗号分隔。</p>
       </div>
       <div class="form-group">

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -28,7 +28,7 @@
       </div>
       <div class="detail-info-row">
         <span class="detail-info-label">简介</span>
-        <span class="detail-info-value">{{ user.username }} 的 Gatherly 个人主页</span>
+        <span class="detail-info-value profile-bio">{{ user.bio or '暂未填写个人简介' }}</span>
       </div>
       <div class="detail-info-row">
         <span class="detail-info-label">信用分</span>
@@ -43,7 +43,7 @@
       {% if permissions.interests %}
       <div class="detail-info-row">
         <span class="detail-info-label">兴趣</span>
-        <span class="detail-info-value">
+        <span class="detail-info-value tag-group">
           {% if interests %}
             {% for interest in interests %}<span class="tag">{{ interest }}</span>{% endfor %}
           {% else %}

--- a/init_db.py
+++ b/init_db.py
@@ -6,12 +6,13 @@ import os
 from werkzeug.security import generate_password_hash
 
 from app import create_app
-from app.models import User, db
+from app.models import User, db, ensure_user_account_schema
 
 app = create_app()
 
 with app.app_context():
     db.create_all()
+    ensure_user_account_schema()
     print("数据库初始化完成！")
     print("数据库文件: gatherly.db")
 


### PR DESCRIPTION
## 关联 Issue
Closes #182 

## 本次完成内容
- 在个人资料编辑页增加个人简介编辑功能
- 增加兴趣标签编辑功能，支持逗号分隔保存
- 在个人主页展示用户简介和兴趣标签
- 补充表单校验和友好提示
- 保持页面表单风格与 Gatherly 现有设计一致

## 自测情况
- [ ] 登录用户可以进入个人资料编辑页
- [ ] 可以修改昵称、邮箱、简介和兴趣标签
- [ ] 保存后个人主页能显示最新资料
- [ ] 简介为空或兴趣为空时页面不报错
- [ ] 已运行 `python -m compileall app`
- [ ] 已运行 `python init_db.py`
- [ ] 已运行 `git diff --check`

## 主要修改文件
- app/models.py
- app/routes/profile.py
- app/templates/profile.html
- app/templates/profile_edit.html
- app/static/css/style.css

## 需要 Review 的重点
请重点检查新增字段是否兼容旧数据库，以及个人主页和编辑页展示是否一致。