### PR TITLE
feat(US-15): 增加同好圈圈主管理功能

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -120,7 +120,9 @@ class Circle(db.Model):
     name = db.Column(db.String(120), nullable=False)
     tag = db.Column(db.String(50))
     description = db.Column(db.Text)
+    announcement = db.Column(db.Text)
     owner_id = db.Column(db.Integer, db.ForeignKey("user.id"))
+    pinned_post_id = db.Column(db.Integer, db.ForeignKey("post.id"))
     is_system = db.Column(db.Boolean, default=False, nullable=False)
     initial_member_count = db.Column(db.Integer, default=0, nullable=False)
     member_count = db.Column(db.Integer, default=0, nullable=False)
@@ -133,9 +135,10 @@ class Circle(db.Model):
         nullable=False,
     )
 
-    posts = db.relationship("Post", back_populates="circle")
+    posts = db.relationship("Post", back_populates="circle", foreign_keys="Post.circle_id")
     members = db.relationship("CircleMember", back_populates="circle")
     owner = db.relationship("User", foreign_keys=[owner_id])
+    pinned_post = db.relationship("Post", foreign_keys=[pinned_post_id], post_update=True)
 
 
 class Post(db.Model):
@@ -149,7 +152,7 @@ class Post(db.Model):
     circle_id = db.Column(db.Integer, db.ForeignKey("circle.id"), nullable=False)
 
     user = db.relationship("User", back_populates="posts")
-    circle = db.relationship("Circle", back_populates="posts")
+    circle = db.relationship("Circle", back_populates="posts", foreign_keys=[circle_id])
     comments = db.relationship("Comment", back_populates="post")
     images = db.relationship(
         "PostImage",

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -499,6 +499,10 @@ def _delete_post_record(post):
     Interaction.query.filter_by(target_type="post", target_id=post.id).delete(
         synchronize_session=False,
     )
+    Circle.query.filter_by(pinned_post_id=post.id).update(
+        {"pinned_post_id": None},
+        synchronize_session=False,
+    )
     db.session.delete(post)
 
 

--- a/app/routes/circle.py
+++ b/app/routes/circle.py
@@ -74,6 +74,10 @@ def _ensure_circle_columns():
     statements = []
     if "owner_id" not in existing_columns:
         statements.append("ALTER TABLE circle ADD COLUMN owner_id INTEGER")
+    if "announcement" not in existing_columns:
+        statements.append("ALTER TABLE circle ADD COLUMN announcement TEXT")
+    if "pinned_post_id" not in existing_columns:
+        statements.append("ALTER TABLE circle ADD COLUMN pinned_post_id INTEGER")
     if "is_system" not in existing_columns:
         statements.append("ALTER TABLE circle ADD COLUMN is_system BOOLEAN NOT NULL DEFAULT 0")
     if "member_count" not in existing_columns:
@@ -85,6 +89,23 @@ def _ensure_circle_columns():
 
     for statement in statements:
         db.session.execute(text(statement))
+    member_rows = db.session.execute(text("PRAGMA table_info(circle_member)")).fetchall()
+    member_columns = {row[1] for row in member_rows}
+    if member_rows and "role" not in member_columns:
+        db.session.execute(
+            text("ALTER TABLE circle_member ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'member'")
+        )
+        statements.append("ALTER TABLE circle_member ADD COLUMN role")
+    normalized_roles = 0
+    legacy_role_count = 0
+    if member_rows:
+        legacy_role_count = db.session.execute(
+            text("SELECT COUNT(*) FROM circle_member WHERE role = 'admin'")
+        ).scalar()
+    if legacy_role_count:
+        normalized_roles = db.session.execute(
+            text("UPDATE circle_member SET role = 'moderator' WHERE role = 'admin'")
+        ).rowcount
     if rows and "initial_member_count" not in existing_columns:
         db.session.execute(
             text(
@@ -104,7 +125,7 @@ def _ensure_circle_columns():
         )
     if rows and "updated_at" not in existing_columns:
         db.session.execute(text("UPDATE circle SET updated_at = created_at WHERE updated_at IS NULL"))
-    if statements:
+    if statements or normalized_roles:
         db.session.commit()
 
 
@@ -259,6 +280,18 @@ def _circle_member_role(circle_id, user_id):
     return member.role if member else None
 
 
+def _can_manage_circle(user, circle):
+    if user is None:
+        return False
+    if user.role == "admin" or circle.owner_id == user.id:
+        return True
+    return _circle_member_role(circle.id, user.id) in {"owner", "moderator", "admin"}
+
+
+def _is_circle_owner(user, circle):
+    return bool(user and circle.owner_id == user.id)
+
+
 def _can_manage_circle_content(user, circle, author_id):
     if user is None:
         return False
@@ -266,9 +299,7 @@ def _can_manage_circle_content(user, circle, author_id):
         return True
     if author_id == user.id:
         return True
-    if circle.owner_id == user.id:
-        return True
-    return _circle_member_role(circle.id, user.id) in {"owner", "admin"}
+    return _can_manage_circle(user, circle)
 
 
 def _can_view_circle(user, circle):
@@ -518,7 +549,10 @@ def circle_detail(circle_id):
         post_query = post_query.filter(Post.status.in_(["published", "hidden"]))
     else:
         post_query = post_query.filter_by(status="published")
-    posts = post_query.order_by(Post.created_at.desc()).all()
+    posts = post_query.order_by(
+        (Post.id == circle.pinned_post_id).desc(),
+        Post.created_at.desc(),
+    ).all()
     post_items = []
     for post in posts:
         comments = (
@@ -529,6 +563,7 @@ def circle_detail(circle_id):
         post_items.append(
             {
                 "post": post,
+                "is_pinned": post.id == circle.pinned_post_id,
                 "counts": _interaction_counts("post", post.id),
                 "states": _user_interaction_states(
                     current_user.id if current_user else None,
@@ -544,12 +579,21 @@ def circle_detail(circle_id):
                 ),
             }
         )
+    active_members = (
+        CircleMember.query.filter_by(circle_id=circle.id, status="active")
+        .join(User, CircleMember.user_id == User.id)
+        .order_by(User.nickname.asc(), User.username.asc())
+        .all()
+    )
     return render_template(
         "circle_detail.html",
         circle=_decorate_circle(circle),
         posts=post_items,
         current_user=current_user,
         is_member=_is_member(circle.id),
+        can_manage_circle=_can_manage_circle(current_user, circle),
+        is_circle_owner=_is_circle_owner(current_user, circle),
+        circle_members=active_members,
     )
 
 
@@ -569,6 +613,7 @@ def join_circle(circle_id):
         db.session.add(CircleMember(circle_id=circle.id, user_id=user.id, role="member"))
     elif member.status != "active":
         member.status = "active"
+        member.role = "owner" if circle.owner_id == user.id else "member"
         member.updated_at = datetime.utcnow()
     else:
         flash("您已经加入该同好圈。", "info")
@@ -605,11 +650,122 @@ def leave_circle(circle_id):
         flash("您尚未加入该同好圈。", "info")
         return redirect(url_for("circle.circle_detail", circle_id=circle.id))
 
+    if circle.owner_id == user.id:
+        flash("请先将圈主身份转移给其他成员，再退出圈子。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
     member.status = "inactive"
+    member.role = "member"
     member.updated_at = datetime.utcnow()
     _refresh_member_count(circle)
     db.session.commit()
     flash("已退出同好圈。", "success")
+    return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+
+@circle_bp.route("/circle/<int:circle_id>/announcement", methods=["POST"])
+def update_announcement(circle_id):
+    user = _current_user()
+    circle = Circle.query.get_or_404(circle_id)
+    if not _can_manage_circle(user, circle):
+        flash("没有权限编辑圈内公告。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    announcement = request.form.get("announcement", "").strip()
+    if len(announcement) > 1000:
+        flash("圈内公告不能超过 1000 个字符。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    circle.announcement = announcement or None
+    db.session.commit()
+    flash("圈内公告已更新。", "success")
+    return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+
+@circle_bp.route("/circle/<int:circle_id>/post/<int:post_id>/pin", methods=["POST"])
+def toggle_pin_post(circle_id, post_id):
+    user = _current_user()
+    circle = Circle.query.get_or_404(circle_id)
+    if not _can_manage_circle(user, circle):
+        flash("没有权限置顶圈内帖子。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    post = Post.query.filter_by(id=post_id, circle_id=circle.id, status="published").first()
+    if post is None:
+        flash("只能置顶当前圈子内正常显示的帖子。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    if circle.pinned_post_id == post.id:
+        circle.pinned_post_id = None
+        message = "已取消置顶帖子。"
+    else:
+        circle.pinned_post_id = post.id
+        message = "帖子已置顶。"
+    db.session.commit()
+    flash(message, "success")
+    return redirect(url_for("circle.circle_detail", circle_id=circle.id, _anchor=f"post-{post.id}"))
+
+
+@circle_bp.route("/circle/<int:circle_id>/member/<int:user_id>/role", methods=["POST"])
+def update_circle_member_role(circle_id, user_id):
+    user = _current_user()
+    circle = Circle.query.get_or_404(circle_id)
+    if not _is_circle_owner(user, circle):
+        flash("只有圈主可以设置圈子管理员。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    member = CircleMember.query.filter_by(
+        circle_id=circle.id,
+        user_id=user_id,
+        status="active",
+    ).first()
+    if member is None:
+        flash("只能管理当前圈内成员。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+    if member.user_id == circle.owner_id:
+        flash("圈主身份不能通过管理员设置修改。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    role = request.form.get("role", "").strip()
+    if role not in {"moderator", "member"}:
+        flash("不支持的圈内角色。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    member.role = role
+    db.session.commit()
+    flash("圈子管理员设置已更新。", "success")
+    return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+
+@circle_bp.route("/circle/<int:circle_id>/transfer-owner", methods=["POST"])
+def transfer_circle_owner(circle_id):
+    user = _current_user()
+    circle = Circle.query.get_or_404(circle_id)
+    if not _is_circle_owner(user, circle):
+        flash("只有圈主可以转移圈主身份。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    target_user_id = request.form.get("user_id", type=int)
+    target = CircleMember.query.filter_by(
+        circle_id=circle.id,
+        user_id=target_user_id,
+        status="active",
+    ).first()
+    if target is None or target.user_id == circle.owner_id:
+        flash("请选择其他圈内成员接任圈主。", "error")
+        return redirect(url_for("circle.circle_detail", circle_id=circle.id))
+
+    previous_owner = CircleMember.query.filter_by(
+        circle_id=circle.id,
+        user_id=circle.owner_id,
+        status="active",
+    ).first()
+    if previous_owner is not None:
+        previous_owner.role = "member"
+    target.role = "owner"
+    circle.owner_id = target.user_id
+    db.session.commit()
+    flash("圈主身份已转移。", "success")
     return redirect(url_for("circle.circle_detail", circle_id=circle.id))
 
 
@@ -733,6 +889,8 @@ def delete_post(post_id):
         flash("没有权限删除该内容。", "error")
         return redirect(url_for("circle.circle_detail", circle_id=circle.id, _anchor=f"post-{post.id}"))
 
+    if circle.pinned_post_id == post.id:
+        circle.pinned_post_id = None
     post.status = "deleted"
     db.session.commit()
     flash("帖子已删除。", "success")

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -682,6 +682,10 @@ def delete_post(post_id):
         flash("该帖子已经删除。", "info")
         return redirect(fallback_url)
 
+    Circle.query.filter_by(pinned_post_id=post.id).update(
+        {"pinned_post_id": None},
+        synchronize_session=False,
+    )
     post.status = "deleted"
     db.session.commit()
     flash("帖子已删除。", "success")

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2518,6 +2518,122 @@ textarea.form-input {
   display: inline;
 }
 
+.circle-announcement,
+.circle-management-panel {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: #fbfaf7;
+}
+
+.circle-announcement p {
+  margin: 6px 0 0;
+  white-space: pre-wrap;
+}
+
+.circle-management-panel summary {
+  cursor: pointer;
+  color: var(--color-primary-dark);
+  font-weight: 700;
+}
+
+.circle-management-panel form {
+  margin-top: 14px;
+}
+
+.management-card {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.circle-management-title {
+  margin: 0 0 8px;
+  font-size: 18px;
+}
+
+.management-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.management-button {
+  min-width: 112px;
+  min-height: 36px;
+}
+
+.member-picker-search {
+  margin-top: 6px;
+}
+
+.member-picker-list {
+  display: grid;
+  gap: 0;
+  margin-top: 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.circle-member-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 8px 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.circle-member-info {
+  display: grid;
+  gap: 2px;
+  min-width: 180px;
+  margin-right: auto;
+}
+
+.circle-member-info span,
+.member-picker-empty {
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.member-picker .is-hidden {
+  display: none;
+}
+
+.circle-member-row form {
+  margin: 0;
+}
+
+.circle-management-action {
+  border-color: var(--color-primary);
+}
+
+.circle-pinned-tag {
+  background: #fff1cc;
+  color: #8a5a1f;
+}
+
+@media (max-width: 640px) {
+  .circle-management-panel,
+  .management-card {
+    padding: 12px;
+  }
+
+  .management-actions,
+  .circle-member-row,
+  .circle-member-row form {
+    width: 100%;
+  }
+
+  .management-button {
+    width: 100%;
+  }
+}
+
 .account-settings-container {
   max-width: 720px;
 }

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -212,4 +212,32 @@ document.addEventListener("DOMContentLoaded", () => {
       target.textContent = count > 0 ? `已选择 ${count} 张图片` : "未选择图片";
     });
   });
+
+  document.querySelectorAll("[data-member-picker]").forEach(picker => {
+    const search = picker.querySelector("[data-member-search]");
+    const members = picker.querySelectorAll("[data-member-item]");
+    const emptyMessage = picker.querySelector("[data-member-empty]");
+    if (!search) {
+      return;
+    }
+
+    const filterMembers = () => {
+      const query = search.value.trim().toLocaleLowerCase();
+      let visibleCount = 0;
+      members.forEach(member => {
+        const searchText = (member.dataset.memberSearchText || "").toLocaleLowerCase();
+        const isVisible = !query || searchText.includes(query);
+        member.classList.toggle("is-hidden", !isVisible);
+        if (isVisible) {
+          visibleCount += 1;
+        }
+      });
+      if (emptyMessage) {
+        emptyMessage.classList.toggle("is-hidden", visibleCount > 0);
+      }
+    };
+
+    search.addEventListener("input", filterMembers);
+    filterMembers();
+  });
 });

--- a/app/templates/circle_detail.html
+++ b/app/templates/circle_detail.html
@@ -103,7 +103,82 @@
                 <p>{{ circle.member_count }} 位成员</p>
                 <p>{{ circle.post_count | default(0) }} 篇帖子</p>
                 <p>{{ circle.active_level }}</p>
+                <p>圈主：{{ (circle.owner.nickname or circle.owner.username) if circle.owner else '暂未设置' }}</p>
             </div>
+
+            <div class="circle-announcement">
+                <strong>圈内公告</strong>
+                <p>{{ circle.announcement or '暂无公告。' }}</p>
+            </div>
+
+            {% if can_manage_circle %}
+            <details class="circle-management-panel">
+                <summary>管理圈子</summary>
+                <section class="management-card">
+                    <h2 class="circle-management-title">编辑圈内公告</h2>
+                    <form method="POST" action="{{ url_for('circle.update_announcement', circle_id=circle.id) }}">
+                        <label class="form-label" for="announcement">公告内容</label>
+                        <textarea class="form-input" id="announcement" name="announcement" rows="4" maxlength="1000">{{ circle.announcement or '' }}</textarea>
+                        <div class="management-actions">
+                            <button class="button button-small management-button" type="submit">保存公告</button>
+                        </div>
+                    </form>
+                </section>
+
+                {% if is_circle_owner %}
+                <section class="management-card member-picker" data-member-picker>
+                    <h2 class="circle-management-title">设置管理员</h2>
+                    <p class="form-hint">按昵称、用户名或邮箱搜索当前圈内成员。</p>
+                    <label class="form-label" for="moderator-member-search">搜索成员</label>
+                    <input class="form-input member-picker-search" id="moderator-member-search" type="search" placeholder="输入昵称、用户名或邮箱" autocomplete="off" data-member-search>
+                    <div class="member-picker-list" data-member-list>
+                        {% for membership in circle_members %}
+                            {% if membership.user_id != circle.owner_id %}
+                            <div class="circle-member-row" data-member-item data-member-search-text="{{ membership.user.nickname or '' }} {{ membership.user.username }} {{ membership.user.email }}">
+                                <div class="circle-member-info">
+                                    <strong>{{ membership.user.nickname or membership.user.username }}</strong>
+                                    <span>@{{ membership.user.username }} · {{ membership.user.email }}</span>
+                                </div>
+                                <span class="tag">{{ '管理员' if membership.role in ['moderator', 'admin'] else '成员' }}</span>
+                                <form method="POST" action="{{ url_for('circle.update_circle_member_role', circle_id=circle.id, user_id=membership.user_id) }}">
+                                    <input type="hidden" name="role" value="{{ 'member' if membership.role in ['moderator', 'admin'] else 'moderator' }}">
+                                    <button class="button button-small management-button {{ 'button-danger' if membership.role in ['moderator', 'admin'] else 'button-secondary' }}" type="submit">
+                                        {{ '移除管理员' if membership.role in ['moderator', 'admin'] else '设为管理员' }}
+                                    </button>
+                                </form>
+                            </div>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                    <p class="member-picker-empty is-hidden" data-member-empty>没有匹配的圈内成员。</p>
+                </section>
+
+                <section class="management-card member-picker" data-member-picker>
+                    <h2 class="circle-management-title">转移圈主</h2>
+                    <p class="form-hint">转移后你将成为普通成员，请谨慎操作。</p>
+                    <label class="form-label" for="owner-member-search">搜索接任成员</label>
+                    <input class="form-input member-picker-search" id="owner-member-search" type="search" placeholder="输入昵称、用户名或邮箱" autocomplete="off" data-member-search>
+                    <div class="member-picker-list" data-member-list>
+                        {% for membership in circle_members %}
+                            {% if membership.user_id != circle.owner_id %}
+                            <div class="circle-member-row" data-member-item data-member-search-text="{{ membership.user.nickname or '' }} {{ membership.user.username }} {{ membership.user.email }}">
+                                <div class="circle-member-info">
+                                    <strong>{{ membership.user.nickname or membership.user.username }}</strong>
+                                    <span>@{{ membership.user.username }} · {{ membership.user.email }}</span>
+                                </div>
+                                <form method="POST" action="{{ url_for('circle.transfer_circle_owner', circle_id=circle.id) }}" onsubmit="return confirm('确定将圈主身份转移给该成员吗？');">
+                                    <input type="hidden" name="user_id" value="{{ membership.user_id }}">
+                                    <button class="button button-small button-danger management-button" type="submit">转移圈主</button>
+                                </form>
+                            </div>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                    <p class="member-picker-empty is-hidden" data-member-empty>没有匹配的圈内成员。</p>
+                </section>
+                {% endif %}
+            </details>
+            {% endif %}
 
             {% if current_user %}
                 {% if is_member %}
@@ -136,6 +211,7 @@
                             <span>{{ post.user.nickname or post.user.username }}</span>
                         </a>
                         <span class="tag">{{ post.type }}</span>
+                        {% if item.is_pinned %}<span class="tag circle-pinned-tag">置顶</span>{% endif %}
                     </div>
                     <h2 class="card-title">{{ post.title }}</h2>
                     <p class="circle-description">{{ post.content }}</p>
@@ -168,6 +244,11 @@
                             type="button"
                             data-share-url="{{ url_for('circle.circle_detail', circle_id=circle.id, _anchor='post-' ~ post.id) }}"
                         >转发</button>
+                        {% if can_manage_circle %}
+                        <form method="POST" action="{{ url_for('circle.toggle_pin_post', circle_id=circle.id, post_id=post.id) }}">
+                            <button class="circle-action-button circle-management-action" type="submit">{{ '取消置顶' if item.is_pinned else '置顶' }}</button>
+                        </form>
+                        {% endif %}
                         {% if item.can_delete %}
                         <form method="POST" action="{{ url_for('circle.delete_post', post_id=post.id) }}" onsubmit="return confirm('确定删除这篇帖子吗？');">
                             <button class="circle-action-button circle-delete-button" type="submit">删除</button>


### PR DESCRIPTION
## 关联 Issue
Closes #xxx
Closes #xxx
Closes #xxx
Closes #xxx
Closes #xxx

对应功能：
- [US-15-14] 第一个创建同好圈的用户自动成为圈主
- [US-15-15] 圈主可以发布和编辑圈内公告
- [US-15-16] 圈主可以置顶圈内帖子
- [US-15-17] 圈主可以添加或移除圈子管理员
- [US-15-18] 圈主可以转移圈主身份

## 本次完成内容
- 新增同好圈圈主权限逻辑
- 用户创建普通同好圈后自动成为圈主
- 圈主默认加入自己创建的圈子
- 圈子详情页显示圈主信息
- 增加圈内公告编辑功能
- 增加圈内帖子置顶和取消置顶功能
- 增加圈子管理员设置和移除功能
- 增加圈主转移功能
- 所有管理操作均进行后端权限校验
-优化同好圈圈主管理界面，在设置管理员和转移圈主功能中加入成员搜索，并统一各个管理按钮的大小、位置和视觉层级

## 自测情况
- [ ] 创建同好圈后，创建者自动成为圈主
- [ ] 圈主可以编辑圈内公告
- [ ] 普通成员不能编辑圈内公告
- [ ] 圈主可以置顶和取消置顶帖子
- [ ] 圈主可以添加或移除圈子管理员
- [ ] 管理员不能移除圈主
- [ ] 圈主可以转移圈主身份给圈内成员
- [ ] 转移后新圈主拥有管理权限
- [ ] 旧圈子没有圈主时页面不报错
- [ ] 已运行 `python -m compileall app`
- [ ] 已运行 `python init_db.py`
- [ ] 已运行 `git diff --check`
- [ ] 圈主设置管理员时，可以按昵称或邮箱搜索圈内成员
- [ ] 圈主转移圈主身份时，可以按昵称或邮箱搜索圈内成员
- [ ] 搜索范围只包含当前圈子的成员
- [ ] 普通成员不能看到圈主管理搜索区域
- [ ] 管理员按钮、转移圈主按钮、公告按钮、置顶按钮大小统一
- [ ] 主要操作按钮、次要操作按钮、危险操作按钮有清晰区别
- [ ] 桌面端按钮靠近对应操作区域，移动端按钮不拥挤、不溢出
- [ ] 不引入 React/Vue/Bootstrap 等新技术栈

## 建议修改文件
- app/routes/circle.py
- app/templates/circle_detail.html
- app/static/js/main.js 或 app/static/js/circle.js
- app/static/css/style.css

## 分支命名建议
enh/enh-04-circle-management-ui

## Commit 示例
enh(ENH-04): 优化同好圈管理成员搜索和按钮布局


## 主要修改文件
- app/models.py
- app/routes/circle.py
- app/templates/circle.html
- app/templates/circle_detail.html
- app/static/css/style.css

## 需要 Review 的重点
请重点检查权限边界：普通成员不能调用管理接口，圈子管理员不能越权操作圈主，圈主转移后权限是否正确更新。