### PR TITLE
feat(US-16-09): 增加管理员置顶同好圈功能

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -123,6 +123,8 @@ class Circle(db.Model):
     announcement = db.Column(db.Text)
     owner_id = db.Column(db.Integer, db.ForeignKey("user.id"))
     pinned_post_id = db.Column(db.Integer, db.ForeignKey("post.id"))
+    is_pinned = db.Column(db.Boolean, default=False, nullable=False)
+    pinned_at = db.Column(db.DateTime)
     is_system = db.Column(db.Boolean, default=False, nullable=False)
     initial_member_count = db.Column(db.Integer, default=0, nullable=False)
     member_count = db.Column(db.Integer, default=0, nullable=False)

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -420,6 +420,32 @@ def update_circle_status(circle_id):
     return _update_status(Circle, circle_id, CIRCLE_STATUSES, "同好圈", "admin.admin_circles")
 
 
+@admin_bp.route("/admin/circles/<int:circle_id>/pin", methods=["POST"])
+@admin_required
+def toggle_circle_pin(circle_id):
+    _ensure_admin_schema()
+    circle = Circle.query.get(circle_id)
+    if circle is None or circle.status == "deleted":
+        flash("同好圈不存在或已被删除。", "error")
+        return redirect(url_for("admin.admin_circles"))
+
+    circle.is_pinned = not circle.is_pinned
+    circle.pinned_at = datetime.utcnow() if circle.is_pinned else None
+    log_admin_action(
+        get_current_user().id,
+        "pin_circle" if circle.is_pinned else "unpin_circle",
+        "同好圈",
+        circle.id,
+        f"is_pinned: {not circle.is_pinned} -> {circle.is_pinned}; name: {circle.name}",
+    )
+    db.session.commit()
+    flash(
+        f"同好圈“{circle.name}”已{'置顶' if circle.is_pinned else '取消置顶'}。",
+        "success",
+    )
+    return redirect(url_for("admin.admin_circles"))
+
+
 @admin_bp.route("/admin/posts")
 @admin_required
 def admin_posts():

--- a/app/routes/circle.py
+++ b/app/routes/circle.py
@@ -78,6 +78,10 @@ def _ensure_circle_columns():
         statements.append("ALTER TABLE circle ADD COLUMN announcement TEXT")
     if "pinned_post_id" not in existing_columns:
         statements.append("ALTER TABLE circle ADD COLUMN pinned_post_id INTEGER")
+    if "is_pinned" not in existing_columns:
+        statements.append("ALTER TABLE circle ADD COLUMN is_pinned BOOLEAN NOT NULL DEFAULT 0")
+    if "pinned_at" not in existing_columns:
+        statements.append("ALTER TABLE circle ADD COLUMN pinned_at DATETIME")
     if "is_system" not in existing_columns:
         statements.append("ALTER TABLE circle ADD COLUMN is_system BOOLEAN NOT NULL DEFAULT 0")
     if "member_count" not in existing_columns:
@@ -463,6 +467,8 @@ def circles():
     circle_rows = (
         Circle.query.filter_by(status="active")
         .order_by(
+            Circle.is_pinned.desc(),
+            Circle.pinned_at.desc(),
             Circle.is_system.desc(),
             Circle.member_count.desc(),
             func.coalesce(Circle.updated_at, Circle.created_at).desc(),

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1262,6 +1262,11 @@ img {
   color: #8a5a1f;
 }
 
+.circle-admin-pinned-tag {
+  background: #f8e8e4;
+  color: #8b4638;
+}
+
 .circle-meta {
   display: flex;
   flex-wrap: wrap;

--- a/app/templates/admin_circles.html
+++ b/app/templates/admin_circles.html
@@ -9,15 +9,16 @@
   <div class="page-title"><p class="eyebrow">Admin Circles</p><h1>同好圈管理</h1><p>查看全部同好圈，并隐藏、恢复显示或删除内容。</p></div>
   {{ list_filters('admin.admin_circles', filters, status_options, type_options) }}
   <div class="admin-table-wrap"><table class="admin-table">
-    <thead><tr><th>ID</th><th>名称</th><th>简介摘要</th><th>创建时间</th><th>帖子数</th><th>状态</th><th>操作</th></tr></thead>
+    <thead><tr><th>ID</th><th>名称</th><th>简介摘要</th><th>创建时间</th><th>帖子数</th><th>状态</th><th>置顶状态</th><th>操作</th></tr></thead>
     <tbody>{% for circle, post_count in circles %}<tr>
-      <td>{{ circle.id }}</td><td>{{ circle.name }}</td><td class="admin-summary">{{ circle.description|default('-', true)|truncate(60, true) }}</td><td>{{ circle.created_at.strftime('%Y-%m-%d %H:%M') }}</td><td>{{ post_count }}</td><td><span class="admin-status status-{{ circle.status }}">{{ '已隐藏' if circle.status == 'hidden' else '正常' }}</span></td>
+      <td>{{ circle.id }}</td><td>{{ circle.name }}</td><td class="admin-summary">{{ circle.description|default('-', true)|truncate(60, true) }}</td><td>{{ circle.created_at.strftime('%Y-%m-%d %H:%M') }}</td><td>{{ post_count }}</td><td><span class="admin-status status-{{ circle.status }}">{{ '已隐藏' if circle.status == 'hidden' else '正常' }}</span></td><td><span class="admin-status {{ 'status-pinned' if circle.is_pinned else 'status-unpinned' }}">{{ '已置顶' if circle.is_pinned else '未置顶' }}</span></td>
       <td><div class="admin-action-group">
         <a class="button button-small button-secondary" href="{{ url_for('circle.circle_detail', circle_id=circle.id) }}">查看</a>
+        <form method="post" action="{{ url_for('admin.toggle_circle_pin', circle_id=circle.id) }}"><button class="button button-small button-secondary" type="submit">{{ '取消置顶' if circle.is_pinned else '置顶' }}</button></form>
         <form method="post" action="{{ url_for('admin.update_circle_status', circle_id=circle.id) }}"><input type="hidden" name="status" value="{{ 'active' if circle.status == 'hidden' else 'hidden' }}"><button class="button button-small button-secondary" type="submit">{{ '恢复显示' if circle.status == 'hidden' else '隐藏' }}</button></form>
         <form method="post" action="{{ url_for('admin.delete_circle', circle_id=circle.id) }}" onsubmit="return confirm('确定删除这个同好圈吗？圈内帖子和评论也会被删除。');"><button class="button button-small button-danger" type="submit">删除</button></form>
       </div></td>
-    </tr>{% else %}<tr><td class="admin-empty" colspan="7">暂无同好圈。</td></tr>{% endfor %}</tbody>
+    </tr>{% else %}<tr><td class="admin-empty" colspan="8">暂无同好圈。</td></tr>{% endfor %}</tbody>
   </table></div>
 </div></section>
 {% endblock %}

--- a/app/templates/circle.html
+++ b/app/templates/circle.html
@@ -60,6 +60,7 @@
                     <div class="card-tags">
                         <span class="tag">{{ circle.tag or "同好圈" }}</span>
                         <span class="tag circle-active-tag">{{ circle.active_level }}</span>
+                        {% if circle.is_pinned %}<span class="tag circle-admin-pinned-tag">管理员置顶</span>{% endif %}
                     </div>
                     <h3 class="card-title">
                         <a href="{{ url_for('circle.circle_detail', circle_id=circle.id) }}">{{ circle.name }}</a>


### PR DESCRIPTION
## 关联 Issue
Closes #190 

## 本次完成内容
- 在后台管理的同好圈板块增加置顶状态显示
- 管理员可以置顶指定同好圈
- 管理员可以取消置顶指定同好圈
- 前台同好圈列表优先展示管理员置顶圈子
- 多个置顶圈子按置顶时间或更新时间排序
- 保留已有同好圈查看、隐藏、删除功能

## 自测情况
- [ ] 管理员可以进入后台同好圈管理页面
- [ ] 管理员可以置顶同好圈
- [ ] 管理员可以取消置顶同好圈
- [ ] 普通用户不能访问管理员置顶接口
- [ ] 前台同好圈列表置顶圈子优先显示
- [ ] 隐藏/删除同好圈功能没有被破坏
- [ ] 已运行 `python -m compileall app`
- [ ] 已运行 `python init_db.py`
- [ ] 已运行 `git diff --check`

## 主要修改文件
- app/models.py
- app/routes/admin.py
- app/routes/circle.py
- app/templates/admin/circles.html
- app/templates/circle.html
- app/static/css/style.css

## 需要 Review 的重点
请重点检查管理员置顶同好圈和圈主置顶圈内帖子是否互不影响，这是两个不同层级的置顶功能。