### PR TITLE
fix: add email validator dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask>=3.0
 Flask-SQLAlchemy
 Flask-WTF
 Werkzeug
+email-validator


### PR DESCRIPTION
## 关联 Issue
无，部署依赖修复

## 本次完成内容
- 在 requirements.txt 中补充 email-validator
- 修复部署环境中 WTForms Email 校验缺少依赖的问题

## 自测情况
- [x] PythonAnywhere 已手动安装 email-validator 后网站可正常运行
- [x] 本次 PR 将依赖正式写入 requirements.txt，方便后续部署自动安装

## 主要修改文件
- requirements.txt