### PR TITLE
style(UI-03): 重构全局顶部导航栏

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2729,3 +2729,361 @@ textarea.form-input {
     gap: 4px;
   }
 }
+
+/* ============================================
+   全局顶部导航栏 (UI-03)
+   ============================================ */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-header {
+  background: rgba(255, 255, 255, 0.97);
+}
+
+.navbar {
+  min-height: 72px;
+  gap: 20px;
+  flex-wrap: nowrap;
+}
+
+.brand {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 9px;
+  color: var(--color-primary-dark);
+  font-size: 23px;
+  letter-spacing: -0.5px;
+  white-space: nowrap;
+}
+
+.brand-mark {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 12px 12px 12px 4px;
+  background: var(--color-primary);
+  color: #ffffff;
+  font-size: 20px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.nav-search {
+  display: flex;
+  flex: 1 1 580px;
+  align-items: center;
+  min-width: 280px;
+  max-width: 620px;
+  height: 46px;
+  padding-left: 4px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-surface);
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav-search:focus-within {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(47, 111, 99, 0.12);
+}
+
+.nav-search input {
+  min-width: 0;
+  height: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  font: inherit;
+  font-size: 14px;
+  outline: 0;
+}
+
+.nav-search input:first-of-type {
+  flex: 1 1 250px;
+  padding: 0 14px;
+}
+
+.nav-search-city {
+  flex: 0 1 126px;
+  padding: 0 12px;
+}
+
+.nav-search-divider {
+  flex: 0 0 1px;
+  width: 1px;
+  height: 22px;
+  background: var(--color-border);
+}
+
+.nav-search-submit {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 38px;
+  margin-right: 4px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--color-primary);
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.nav-search-submit:hover {
+  background: var(--color-primary-dark);
+}
+
+.desktop-nav {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 17px;
+  white-space: nowrap;
+}
+
+.desktop-nav > a {
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.desktop-nav > a:hover {
+  color: var(--color-primary);
+}
+
+.desktop-nav .nav-register {
+  padding: 8px 15px;
+  border-radius: 999px;
+  background: var(--color-primary);
+  color: #ffffff;
+}
+
+.desktop-nav .nav-register:hover {
+  background: var(--color-primary-dark);
+  color: #ffffff;
+}
+
+.nav-account {
+  position: relative;
+}
+
+.avatar-button {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.nav-avatar {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 50%;
+  background: #d9eee8;
+  color: var(--color-primary-dark);
+  font-size: 16px;
+  font-weight: 800;
+}
+
+.nav-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.nav-chevron {
+  color: var(--color-muted);
+  font-size: 18px;
+  line-height: 1;
+  transition: transform 0.2s ease;
+}
+
+.avatar-button[aria-expanded="true"] .nav-chevron {
+  transform: rotate(180deg);
+}
+
+.account-menu {
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  display: grid;
+  width: 210px;
+  padding: 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  background: var(--color-surface);
+  box-shadow: 0 10px 26px rgba(34, 34, 34, 0.14);
+}
+
+.account-menu[hidden],
+.mobile-search-panel[hidden],
+.mobile-menu[hidden] {
+  display: none;
+}
+
+.account-menu a {
+  padding: 9px 10px;
+  border-radius: 8px;
+  color: var(--color-text);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.account-menu a:hover {
+  background: #e8f0ed;
+  color: var(--color-primary-dark);
+}
+
+.account-menu-divider {
+  height: 1px;
+  margin: 7px 4px;
+  background: var(--color-border);
+}
+
+.mobile-nav,
+.mobile-search-panel,
+.mobile-menu {
+  display: none;
+}
+
+@media (max-width: 980px) {
+  .navbar {
+    gap: 14px;
+  }
+
+  .nav-search {
+    flex-basis: 400px;
+  }
+
+  .nav-search input:first-of-type {
+    flex-basis: 180px;
+  }
+
+  .nav-search-city {
+    flex-basis: 100px;
+  }
+
+  .desktop-nav {
+    gap: 12px;
+  }
+}
+
+@media (max-width: 760px) {
+  .navbar {
+    min-height: 62px;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .brand {
+    font-size: 21px;
+  }
+
+  .brand-mark {
+    width: 32px;
+    height: 32px;
+    font-size: 18px;
+  }
+
+  .navbar > .nav-search,
+  .desktop-nav {
+    display: none;
+  }
+
+  .mobile-nav {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    margin-left: auto;
+  }
+
+  .mobile-nav-button {
+    display: grid;
+    width: 38px;
+    height: 38px;
+    place-items: center;
+    border: 0;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-text);
+    cursor: pointer;
+    font: inherit;
+    font-size: 20px;
+  }
+
+  .mobile-nav-button:hover {
+    background: #e8f0ed;
+    color: var(--color-primary-dark);
+  }
+
+  .mobile-search-panel,
+  .mobile-menu {
+    display: block;
+    padding-bottom: 14px;
+  }
+
+  .mobile-search-panel .nav-search {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    height: 42px;
+  }
+
+  .mobile-search-panel .nav-search input:first-of-type {
+    flex-basis: 160px;
+    padding: 0 11px;
+  }
+
+  .mobile-search-panel .nav-search-city {
+    flex-basis: 88px;
+    padding: 0 8px;
+  }
+
+  .mobile-search-panel .nav-search-submit {
+    width: 34px;
+    height: 34px;
+    padding: 0;
+  }
+
+  .mobile-menu {
+    display: grid;
+    gap: 2px;
+    border-top: 1px solid var(--color-border);
+    padding-top: 10px;
+  }
+
+  .mobile-menu a {
+    padding: 9px 6px;
+    color: var(--color-text);
+    font-size: 14px;
+    font-weight: 700;
+  }
+
+  .mobile-menu a:hover {
+    color: var(--color-primary);
+  }
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -253,4 +253,68 @@ document.addEventListener("DOMContentLoaded", () => {
     search.addEventListener("input", filterMembers);
     filterMembers();
   });
+
+  const togglePanel = (button, panel, shouldOpen) => {
+    if (!button || !panel) {
+      return;
+    }
+
+    button.setAttribute("aria-expanded", String(shouldOpen));
+    panel.hidden = !shouldOpen;
+  };
+
+  const accountMenuButton = document.querySelector("[data-nav-menu-toggle]");
+  const accountMenu = document.querySelector("[data-nav-menu]");
+  const mobileSearchButton = document.querySelector("[data-mobile-search-toggle]");
+  const mobileSearchPanel = document.querySelector("[data-mobile-search]");
+  const mobileMenuButton = document.querySelector("[data-mobile-menu-toggle]");
+  const mobileMenu = document.querySelector("[data-mobile-menu]");
+
+  const closeNavigationPanels = () => {
+    togglePanel(accountMenuButton, accountMenu, false);
+    togglePanel(mobileSearchButton, mobileSearchPanel, false);
+    togglePanel(mobileMenuButton, mobileMenu, false);
+  };
+
+  if (accountMenuButton && accountMenu) {
+    accountMenuButton.addEventListener("click", event => {
+      event.stopPropagation();
+      const shouldOpen = accountMenu.hidden;
+      closeNavigationPanels();
+      togglePanel(accountMenuButton, accountMenu, shouldOpen);
+    });
+  }
+
+  if (mobileSearchButton && mobileSearchPanel) {
+    mobileSearchButton.addEventListener("click", event => {
+      event.stopPropagation();
+      const shouldOpen = mobileSearchPanel.hidden;
+      closeNavigationPanels();
+      togglePanel(mobileSearchButton, mobileSearchPanel, shouldOpen);
+      if (shouldOpen) {
+        mobileSearchPanel.querySelector("input")?.focus();
+      }
+    });
+  }
+
+  if (mobileMenuButton && mobileMenu) {
+    mobileMenuButton.addEventListener("click", event => {
+      event.stopPropagation();
+      const shouldOpen = mobileMenu.hidden;
+      closeNavigationPanels();
+      togglePanel(mobileMenuButton, mobileMenu, shouldOpen);
+    });
+  }
+
+  document.addEventListener("click", event => {
+    if (!event.target.closest(".site-header")) {
+      closeNavigationPanels();
+    }
+  });
+
+  document.addEventListener("keydown", event => {
+    if (event.key === "Escape") {
+      closeNavigationPanels();
+    }
+  });
 });

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,25 +8,106 @@
 </head>
 <body>
   <header class="site-header">
-    <nav class="navbar container">
-      <a class="brand" href="{{ url_for('activity.index') }}">Gatherly</a>
-      <ul class="nav-links">
-        <li><a href="{{ url_for('activity.index') }}">首页</a></li>
-        <li><a href="{{ url_for('activity.create_activity') }}">发布活动</a></li>
-        <li><a href="{{ url_for('circle.circles') }}">同好圈</a></li>
+    <nav class="navbar container" aria-label="全局导航">
+      <a class="brand" href="{{ url_for('activity.index') }}" aria-label="Gatherly 首页">
+        <span class="brand-mark" aria-hidden="true">G</span>
+        <span>Gatherly</span>
+      </a>
+
+      <form class="nav-search" action="{{ url_for('activity.index') }}" method="get" role="search">
+        <label class="sr-only" for="global-search-keyword">搜索活动、圈子或关键词</label>
+        <input id="global-search-keyword" name="q" type="search" placeholder="搜索活动 / 圈子 / 关键词" autocomplete="off">
+        <span class="nav-search-divider" aria-hidden="true"></span>
+        <label class="sr-only" for="global-search-city">城市或地区</label>
+        <input id="global-search-city" class="nav-search-city" name="city" type="search" placeholder="城市 / 地区" autocomplete="off">
+        <button class="nav-search-submit" type="submit" aria-label="搜索">
+          <span aria-hidden="true">&#128269;</span>
+          <span>搜索</span>
+        </button>
+      </form>
+
+      <div class="desktop-nav">
+        <a href="{{ url_for('activity.create_activity') }}">发布活动</a>
+        <a href="{{ url_for('circle.circles') }}">同好圈</a>
         {% if session.get('user_id') %}
-          <li><a href="{{ url_for('profile.my_profile') }}">个人主页</a></li>
-          {% if current_user and current_user.role == 'admin' %}
-            <li><a href="{{ url_for('admin.admin_dashboard') }}">后台管理</a></li>
-          {% endif %}
-          <li><span class="tag" style="background: var(--color-primary); color: #fff;">{{ session.get('nickname', '用户') }}</span></li>
-          <li><a class="button button-small button-secondary" href="{{ url_for('auth.logout') }}">退出</a></li>
+          <div class="nav-account">
+            <button class="avatar-button" type="button" data-nav-menu-toggle aria-expanded="false" aria-controls="account-menu">
+              <span class="nav-avatar">
+                {% if current_user and current_user.avatar %}
+                  <img src="{{ current_user.avatar }}" alt="">
+                {% else %}
+                  {{ session.get('nickname', '用户')[:1] }}
+                {% endif %}
+              </span>
+              <span class="nav-chevron" aria-hidden="true">&#8964;</span>
+              <span class="sr-only">打开用户菜单</span>
+            </button>
+            <div class="account-menu" id="account-menu" data-nav-menu hidden>
+              <a href="{{ url_for('profile.created_activities') }}">我的活动</a>
+              <a href="{{ url_for('profile.my_circles') }}">我的同好圈</a>
+              <a href="{{ url_for('profile.my_profile') }}">个人主页</a>
+              {% if current_user and current_user.role == 'admin' %}
+                <a href="{{ url_for('admin.admin_dashboard') }}">后台管理</a>
+              {% endif %}
+              <span class="account-menu-divider" aria-hidden="true"></span>
+              <a href="{{ url_for('auth.account_settings') }}">账号设置</a>
+              <a href="{{ url_for('auth.logout') }}">退出登录</a>
+            </div>
+          </div>
         {% else %}
-          <li><a href="{{ url_for('auth.login') }}">登录</a></li>
-          <li><a class="button button-small" href="{{ url_for('auth.register') }}">注册</a></li>
+          <a href="{{ url_for('auth.login') }}">登录</a>
+          <a class="nav-register" href="{{ url_for('auth.register') }}">注册</a>
         {% endif %}
-      </ul>
+      </div>
+
+      <div class="mobile-nav">
+        <button class="mobile-nav-button" type="button" data-mobile-search-toggle aria-expanded="false" aria-controls="mobile-search-panel">
+          <span aria-hidden="true">&#128269;</span>
+          <span class="sr-only">搜索</span>
+        </button>
+        {% if session.get('user_id') %}
+          <a class="mobile-nav-button" href="{{ url_for('profile.my_circle_interactions') }}" aria-label="收藏">
+            <span aria-hidden="true">&#9825;</span>
+          </a>
+        {% else %}
+          <a class="mobile-nav-button" href="{{ url_for('auth.login') }}" aria-label="登录后查看收藏">
+            <span aria-hidden="true">&#9825;</span>
+          </a>
+        {% endif %}
+        <button class="mobile-nav-button" type="button" data-mobile-menu-toggle aria-expanded="false" aria-controls="mobile-menu">
+          <span aria-hidden="true">&#9776;</span>
+          <span class="sr-only">打开菜单</span>
+        </button>
+      </div>
     </nav>
+
+    <div class="mobile-search-panel container" id="mobile-search-panel" data-mobile-search hidden>
+      <form class="nav-search" action="{{ url_for('activity.index') }}" method="get" role="search">
+        <label class="sr-only" for="mobile-search-keyword">搜索活动、圈子或关键词</label>
+        <input id="mobile-search-keyword" name="q" type="search" placeholder="活动 / 圈子 / 关键词" autocomplete="off">
+        <label class="sr-only" for="mobile-search-city">城市或地区</label>
+        <input id="mobile-search-city" class="nav-search-city" name="city" type="search" placeholder="城市 / 地区" autocomplete="off">
+        <button class="nav-search-submit" type="submit" aria-label="搜索"><span aria-hidden="true">&#128269;</span></button>
+      </form>
+    </div>
+
+    <div class="mobile-menu container" id="mobile-menu" data-mobile-menu hidden>
+      <a href="{{ url_for('activity.create_activity') }}">发布活动</a>
+      <a href="{{ url_for('circle.circles') }}">同好圈</a>
+      {% if session.get('user_id') %}
+        <a href="{{ url_for('profile.created_activities') }}">我的活动</a>
+        <a href="{{ url_for('profile.my_circles') }}">我的同好圈</a>
+        <a href="{{ url_for('profile.my_profile') }}">个人主页</a>
+        <a href="{{ url_for('auth.account_settings') }}">账号设置</a>
+        {% if current_user and current_user.role == 'admin' %}
+          <a href="{{ url_for('admin.admin_dashboard') }}">后台管理</a>
+        {% endif %}
+        <a href="{{ url_for('auth.logout') }}">退出登录</a>
+      {% else %}
+        <a href="{{ url_for('auth.login') }}">登录</a>
+        <a href="{{ url_for('auth.register') }}">注册</a>
+      {% endif %}
+    </div>
   </header>
 
   <main>


### PR DESCRIPTION
## 关联 Issue

Closes #199 

## 本次完成内容

- 重构全局顶部导航栏结构
- 左侧保留 Gatherly Logo
- 中间增加活动 / 同好圈 / 城市搜索入口
- 右侧区分未登录和已登录状态
- 未登录状态显示登录 / 注册
- 登录状态显示用户头像或用户名菜单
- 增加用户下拉菜单入口：
  - 我的活动
  - 我的同好圈
  - 个人主页
  - 账号设置
  - 退出登录
- 保持首页、活动详情页、同好圈页使用统一导航栏

## 自测情况

- [ ] 本地可以正常运行
- [ ] 首页导航栏显示正常
- [ ] 活动详情页导航栏显示正常
- [ ] 未登录状态显示登录 / 注册
- [ ] 登录状态显示用户菜单
- [ ] 点击登录、注册、退出等入口没有报错
- [ ] 移动端导航栏没有明显溢出

## 主要修改文件

- app/templates/base.html
- app/static/css/style.css
- app/static/js/main.js

## 需要 Review 的重点

请重点检查：
- 全局导航栏是否影响已有页面布局
- 登录 / 注册 / 退出链接是否仍然正常
- 移动端导航栏是否存在挤压或横向溢出