### PR TITLE
style(UI-04): 重构首页活动发现布局

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -3087,3 +3087,553 @@ textarea.form-input {
     color: var(--color-primary);
   }
 }
+
+/* ============================================
+   Meetup-style activity discovery homepage (UI-04)
+   ============================================ */
+
+.home-intro {
+  padding: 34px 0 20px;
+  background: #ffffff;
+}
+
+.home-intro-inner,
+.home-section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.home-intro h1 {
+  margin: 2px 0 8px;
+  font-size: clamp(30px, 4vw, 46px);
+  line-height: 1.12;
+  letter-spacing: -1px;
+}
+
+.home-intro p,
+.home-section-heading p {
+  margin-bottom: 0;
+  color: var(--color-muted);
+}
+
+.home-section {
+  padding: 32px 0;
+}
+
+.home-section:nth-of-type(even) {
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.home-section-heading {
+  margin-bottom: 18px;
+}
+
+.compact-heading {
+  margin-bottom: 12px;
+}
+
+.home-section-heading h2 {
+  margin: 0 0 4px;
+  font-size: clamp(24px, 3vw, 32px);
+  line-height: 1.2;
+}
+
+.section-link {
+  flex: 0 0 auto;
+  color: var(--color-primary-dark);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.section-link:hover {
+  color: var(--color-primary);
+}
+
+.featured-strip {
+  display: grid;
+  grid-template-columns: 1.35fr 1fr;
+  gap: 16px;
+}
+
+.featured-card {
+  position: relative;
+  display: flex;
+  min-height: 212px;
+  align-items: end;
+  overflow: hidden;
+  padding: 24px;
+  border-radius: 22px;
+  background: linear-gradient(125deg, #215d53, #478f82);
+  color: #ffffff;
+  box-shadow: 0 12px 26px rgba(34, 34, 34, 0.12);
+}
+
+.featured-card::after {
+  position: absolute;
+  right: -28px;
+  bottom: -54px;
+  width: 190px;
+  height: 190px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.13);
+  content: "";
+}
+
+.featured-card-secondary {
+  background: linear-gradient(125deg, #a55f3e, #d68a5f);
+}
+
+.featured-card > div {
+  position: relative;
+  z-index: 1;
+}
+
+.featured-label,
+.demo-badge {
+  display: inline-flex;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.2);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.featured-card h3 {
+  margin: 10px 0 2px;
+  font-size: clamp(20px, 2.4vw, 28px);
+}
+
+.featured-card p {
+  margin-bottom: 12px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.featured-card a {
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.my-activities-panel {
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  background: var(--color-surface);
+  box-shadow: 0 6px 16px rgba(34, 34, 34, 0.06);
+}
+
+.home-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 8px 14px 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.home-tab {
+  padding: 11px 14px 10px;
+  border: 0;
+  border-bottom: 3px solid transparent;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+}
+
+.home-tab.is-active {
+  border-bottom-color: var(--color-primary);
+  color: var(--color-primary-dark);
+}
+
+.home-tab-panel {
+  padding: 18px 22px 20px;
+}
+
+.home-tab-panel p {
+  margin-bottom: 7px;
+  color: var(--color-muted);
+}
+
+.discover-toolbar {
+  display: flex;
+  gap: 9px;
+  margin-bottom: 14px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+
+.filter-pill {
+  flex: 0 0 auto;
+  min-height: 38px;
+  padding: 0 15px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--color-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.filter-pill:hover,
+.filter-pill.is-active {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: #ffffff;
+}
+
+.discover-section .interest-section {
+  padding: 18px;
+  border-radius: 18px;
+}
+
+.discover-section .interest-header {
+  margin-bottom: 12px;
+}
+
+.discover-section .interest-title {
+  font-size: 20px;
+}
+
+.icon-category-nav {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  padding-bottom: 8px;
+  scrollbar-width: thin;
+}
+
+.icon-category {
+  display: grid;
+  flex: 0 0 86px;
+  min-height: 76px;
+  place-items: center;
+  align-content: center;
+  gap: 4px;
+  padding: 8px 7px;
+  border-radius: 14px;
+  text-align: center;
+}
+
+.icon-category span:first-child {
+  font-size: 23px;
+  line-height: 1;
+}
+
+.icon-category span:last-child {
+  font-size: 12px;
+}
+
+.activity-discovery-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: stretch;
+}
+
+.discover-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  border: 1px solid rgba(222, 216, 207, 0.9);
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 6px 16px rgba(34, 34, 34, 0.07);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.discover-card:hover {
+  box-shadow: 0 12px 28px rgba(34, 34, 34, 0.13);
+  transform: translateY(-3px);
+}
+
+.discover-card .card-image {
+  position: relative;
+  height: 174px;
+}
+
+.discover-card .is-placeholder-image {
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #d7ede6, #f5e3cf);
+}
+
+.discover-card .is-placeholder-image img {
+  display: none;
+}
+
+.activity-image-placeholder {
+  color: rgba(47, 111, 99, 0.74);
+  font-size: 48px;
+  text-shadow: 0 5px 12px rgba(47, 111, 99, 0.12);
+}
+
+.discover-card .card-body {
+  flex: 1;
+  padding: 15px;
+}
+
+.card-image-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  gap: 7px;
+}
+
+.card-icon-button {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.92);
+  color: #342f2b;
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.12);
+}
+
+.card-icon-button:hover,
+.favorite-button.is-active {
+  color: #e04f67;
+}
+
+.demo-badge {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  background: rgba(36, 86, 77, 0.9);
+  color: #ffffff;
+}
+
+.discover-card .card-tags {
+  min-height: 26px;
+  margin-bottom: 6px;
+}
+
+.discover-card .tag {
+  min-height: 24px;
+  padding: 2px 8px;
+  font-size: 12px;
+}
+
+.discover-card .card-title {
+  min-height: 46px;
+  font-size: 17px;
+}
+
+.discover-card .card-meta {
+  display: grid;
+  gap: 4px;
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.discover-card .card-host {
+  margin-top: 3px;
+  padding-top: 7px;
+  font-size: 12px;
+}
+
+.card-social,
+.card-footer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 9px;
+}
+
+.card-social {
+  margin-top: auto;
+  padding-top: 10px;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.rating-star {
+  color: #e04f67;
+}
+
+.card-footer-actions {
+  margin-top: 12px;
+}
+
+.copy-link-button,
+.detail-button {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.copy-link-button {
+  padding: 0 11px;
+  border: 1px solid var(--color-border);
+  background: #ffffff;
+  color: var(--color-primary-dark);
+}
+
+.detail-button {
+  flex: 1;
+  padding: 0 13px;
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: #ffffff;
+}
+
+.copy-link-button:hover {
+  background: #e8f0ed;
+}
+
+.detail-button:hover {
+  border-color: var(--color-primary-dark);
+  background: var(--color-primary-dark);
+}
+
+.no-match-tip {
+  margin: 18px 0 0;
+  padding: 18px;
+  border: 1px dashed var(--color-border);
+  border-radius: 14px;
+  color: var(--color-muted);
+  text-align: center;
+}
+
+.popular-circle-grid,
+.trust-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.popular-circle-card,
+.trust-card {
+  padding: 20px;
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 5px 14px rgba(34, 34, 34, 0.06);
+}
+
+.circle-card-icon,
+.trust-card > span {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  margin-bottom: 12px;
+  place-items: center;
+  border-radius: 15px;
+  background: #e8f0ed;
+  font-size: 24px;
+}
+
+.popular-circle-card h3,
+.trust-card h3 {
+  margin: 10px 0 4px;
+  font-size: 18px;
+}
+
+.popular-circle-card p,
+.trust-card p {
+  margin-bottom: 12px;
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.popular-circle-card div {
+  margin-bottom: 12px;
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.share-toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 30;
+  padding: 11px 15px;
+  border-radius: 999px;
+  background: #222222;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 700;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.share-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 900px) {
+  .activity-discovery-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .popular-circle-grid,
+  .trust-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .home-intro {
+    padding-top: 24px;
+  }
+
+  .home-intro-inner,
+  .home-section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .home-intro h1 {
+    font-size: 32px;
+  }
+
+  .home-section {
+    padding: 24px 0;
+  }
+
+  .featured-strip,
+  .activity-discovery-grid,
+  .popular-circle-grid,
+  .trust-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .featured-card {
+    min-height: 176px;
+    padding: 20px;
+  }
+
+  .discover-section .interest-section {
+    margin-bottom: 18px;
+    padding: 14px;
+  }
+
+  .icon-category {
+    flex-basis: 78px;
+    min-height: 70px;
+  }
+
+  .discover-card .card-image {
+    height: 196px;
+  }
+
+  .popular-circle-grid,
+  .trust-grid {
+    gap: 12px;
+  }
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -21,75 +21,75 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 3000);
   });
 
-  // US-06-02: 兴趣标签 chip 点击 — 无刷新客户端筛选
-  const tagChips = document.querySelectorAll(".interest-chip");
-  if (tagChips.length > 0) {
-    tagChips.forEach(chip => {
-      chip.addEventListener("click", (e) => {
-        e.preventDefault();
+  // UI-04: 首页活动分类和时间筛选。
+  const discoverySection = document.querySelector(".discover-section");
+  const tagChips = discoverySection?.querySelectorAll(".interest-chip") || [];
+  const timeFilters = discoverySection?.querySelectorAll("[data-time-filter]") || [];
+  const discoveryCards = discoverySection?.querySelectorAll(".discover-card") || [];
+  let activeTag = discoverySection?.querySelector(".interest-chip.is-active")?.dataset.tag || "all";
+  let activeTime = discoverySection?.querySelector("[data-time-filter].is-active")?.dataset.timeFilter || "any";
 
-        const selectedTag = chip.dataset.tag;
+  const updateFilterStatus = () => {
+    const filterStatus = discoverySection?.querySelector(".filter-status");
+    if (!filterStatus) {
+      return;
+    }
 
-        // 切换 active 状态
-        tagChips.forEach(c => c.classList.remove("is-active"));
-        chip.classList.add("is-active");
+    const label = activeTag === "all" ? "全部活动" : activeTag;
+    filterStatus.innerHTML = "";
+    filterStatus.appendChild(document.createTextNode("当前正在浏览：" + label));
 
-        // 筛选活动卡片
-        const cards = document.querySelectorAll(".activity-card");
-        if (selectedTag === "all") {
-          cards.forEach(card => { card.style.display = ""; });
-        } else {
-          cards.forEach(card => {
-            const tags = card.dataset.tags || "";
-            if (tags.split(",").map(t => t.trim()).includes(selectedTag)) {
-              card.style.display = "";
-            } else {
-              card.style.display = "none";
-            }
-          });
-        }
-
-        // 动态更新 filter-status 区域
-        const filterStatus = document.querySelector(".filter-status");
-        if (filterStatus) {
-          if (selectedTag === "all") {
-            filterStatus.innerHTML = "当前正在浏览：全部活动";
-          } else {
-            const clearLink = document.createElement("a");
-            clearLink.href = "#";
-            clearLink.textContent = "查看全部活动 / 清除筛选";
-            clearLink.addEventListener("click", (ev) => {
-              ev.preventDefault();
-              const allChip = document.querySelector('.interest-chip[data-tag="all"]');
-              if (allChip) allChip.click();
-            });
-            filterStatus.innerHTML = "";
-            filterStatus.appendChild(document.createTextNode("当前正在浏览：" + selectedTag + "  "));
-            filterStatus.appendChild(clearLink);
-          }
-        }
-
-        // 无匹配结果提示
-        let visibleCount = 0;
-        cards.forEach(card => {
-          if (card.style.display !== "none") visibleCount++;
-        });
-        const existingTip = document.querySelector(".no-match-tip");
-        if (visibleCount === 0) {
-          if (!existingTip) {
-            const tip = document.createElement("p");
-            tip.className = "no-match-tip";
-            tip.textContent = "暂无匹配的活动，试试其他标签吧！";
-            if (filterStatus) {
-              filterStatus.insertAdjacentElement("afterend", tip);
-            }
-          }
-        } else {
-          if (existingTip) existingTip.remove();
-        }
+    if (activeTag !== "all" || activeTime !== "any") {
+      const clearLink = document.createElement("a");
+      clearLink.href = "#";
+      clearLink.className = "clear-filter-link";
+      clearLink.textContent = "查看全部活动 / 清除筛选";
+      clearLink.addEventListener("click", event => {
+        event.preventDefault();
+        discoverySection.querySelector('.interest-chip[data-tag="all"]')?.click();
+        discoverySection.querySelector('[data-time-filter="any"]')?.click();
       });
+      filterStatus.appendChild(clearLink);
+    }
+  };
+
+  const applyActivityFilters = () => {
+    let visibleCount = 0;
+    discoveryCards.forEach(card => {
+      const tags = (card.dataset.tags || "").split(",").map(tag => tag.trim());
+      const time = card.dataset.time || "any";
+      const tagMatches = activeTag === "all" || tags.includes(activeTag);
+      const timeMatches = activeTime === "any" || time === activeTime;
+      const isVisible = tagMatches && timeMatches;
+      card.style.display = isVisible ? "" : "none";
+      if (isVisible) {
+        visibleCount += 1;
+      }
     });
-  }
+
+    const noMatchTip = discoverySection?.querySelector(".no-match-tip");
+    if (noMatchTip) {
+      noMatchTip.hidden = visibleCount > 0;
+    }
+    updateFilterStatus();
+  };
+
+  tagChips.forEach(chip => {
+    chip.addEventListener("click", event => {
+      event.preventDefault();
+      activeTag = chip.dataset.tag || "all";
+      tagChips.forEach(item => item.classList.toggle("is-active", item === chip));
+      applyActivityFilters();
+    });
+  });
+
+  timeFilters.forEach(filter => {
+    filter.addEventListener("click", () => {
+      activeTime = filter.dataset.timeFilter || "any";
+      timeFilters.forEach(item => item.classList.toggle("is-active", item === filter));
+      applyActivityFilters();
+    });
+  });
 
   const tagToggle = document.querySelector("[data-tag-toggle]");
   if (tagToggle) {
@@ -106,12 +106,11 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   // US-06-03: 清除筛选链接 — 无刷新跳转到全部
-  const clearFilterLink = document.querySelector(".clear-filter-link");
+  const clearFilterLink = discoverySection?.querySelector(".clear-filter-link");
   if (clearFilterLink) {
     clearFilterLink.addEventListener("click", (e) => {
       e.preventDefault();
-      // 点击"全部"标签，触发筛选切换
-      const allChip = document.querySelector('.interest-chip[data-tag="all"]');
+      const allChip = discoverySection.querySelector('.interest-chip[data-tag="all"]');
       if (allChip) {
         allChip.click();
       }
@@ -154,7 +153,7 @@ document.addEventListener("DOMContentLoaded", () => {
     return copied ? Promise.resolve() : Promise.reject(new Error("copy failed"));
   };
 
-  document.querySelectorAll(".circle-share-button[data-share-url]").forEach(button => {
+  document.querySelectorAll(".circle-share-button[data-share-url], [data-activity-share][data-share-url]").forEach(button => {
     button.addEventListener("click", async () => {
       const shareUrl = new URL(button.dataset.shareUrl, window.location.origin).href;
       try {
@@ -167,6 +166,31 @@ document.addEventListener("DOMContentLoaded", () => {
       } catch (error) {
         showShareToast("复制失败，请手动复制链接");
       }
+    });
+  });
+
+  document.querySelectorAll("[data-favorite-placeholder]").forEach(button => {
+    button.addEventListener("click", () => {
+      const isActive = button.classList.toggle("is-active");
+      button.setAttribute("aria-pressed", String(isActive));
+      button.querySelector("span").innerHTML = isActive ? "&#9829;" : "&#9825;";
+      showShareToast(isActive ? "已添加到收藏预览" : "已取消收藏预览");
+    });
+  });
+
+  const homeTabs = document.querySelectorAll("[data-home-tab]");
+  const homeTabPanels = document.querySelectorAll("[data-home-tab-panel]");
+  homeTabs.forEach(tab => {
+    tab.addEventListener("click", () => {
+      const selectedTab = tab.dataset.homeTab;
+      homeTabs.forEach(item => {
+        const isActive = item === tab;
+        item.classList.toggle("is-active", isActive);
+        item.setAttribute("aria-selected", String(isActive));
+      });
+      homeTabPanels.forEach(panel => {
+        panel.hidden = panel.dataset.homeTabPanel !== selectedTab;
+      });
     });
   });
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,58 +3,164 @@
 {% block title %}首页 - Gatherly{% endblock %}
 
 {% block content %}
-<section class="hero">
-    <div class="hero-content container">
-        <p class="eyebrow">线下小众兴趣活动聚合与同好匹配</p>
-        <h1>找到同频的人，一起把兴趣带到现场。</h1>
-
-        <!-- 搜索栏：US-01-01 首页体验增强 -->
-        <div class="search-bar">
-            <input type="text" placeholder="搜索活动、兴趣或城市..." class="search-input">
-            <button class="button">搜索</button>
+{% macro activity_card(activity, detail_url, demo=false) %}
+<article class="activity-card discover-card" data-tags="{{ activity.tags|join(',') if activity.tags else activity.category }}" data-time="{{ activity.time_filter|default('any') }}">
+    <div class="card-image {% if not activity.image_url %}is-placeholder-image{% endif %}">
+        <img src="{{ activity.image_url or url_for('static', filename='images/placeholder-activity.jpg') }}"
+             alt="{{ activity.title }}"
+             onerror="this.src='{{ url_for('static', filename='images/placeholder-activity.jpg') }}'">
+        {% if not activity.image_url %}<span class="activity-image-placeholder" aria-hidden="true">&#10024;</span>{% endif %}
+        <div class="card-image-actions">
+            <button class="card-icon-button favorite-button" type="button" aria-label="收藏 {{ activity.title }}" aria-pressed="false" data-favorite-placeholder>
+                <span aria-hidden="true">&#9825;</span>
+            </button>
+            <button class="card-icon-button" type="button" aria-label="复制 {{ activity.title }} 的链接" data-activity-share data-share-url="{{ detail_url }}">
+                <span aria-hidden="true">&#8599;</span>
+            </button>
         </div>
+        {% if demo %}<span class="demo-badge">精选</span>{% endif %}
+    </div>
+    <div class="card-body">
+        <div class="card-tags">
+            {% if activity.tags %}
+                {% for tag in activity.tags %}
+                <span class="tag">{{ tag }}</span>
+                {% endfor %}
+            {% elif activity.category %}
+                <span class="tag">{{ activity.category }}</span>
+            {% endif %}
+        </div>
+        <h3 class="card-title">{{ activity.title }}</h3>
+        <div class="card-meta">
+            <p class="meta-time"><span aria-hidden="true">&#128197;</span> {{ activity.time }}</p>
+            <p class="meta-location"><span aria-hidden="true">&#128205;</span> {{ activity.location }}</p>
+            <p class="card-host"><span aria-hidden="true">&#9673;</span> 主办方：{{ activity.organizer|default("Gatherly 活动发起人") }}</p>
+        </div>
+        <div class="card-social">
+            <span><strong>{{ activity.rating|default("4.8") }}</strong> <span class="rating-star" aria-hidden="true">&#9733;</span> 评分</span>
+            <span>{{ activity.current_people|default(activity.attendees|default(0)) }} 人已报名</span>
+        </div>
+        <div class="card-footer-actions">
+            <button class="copy-link-button" type="button" data-activity-share data-share-url="{{ detail_url }}">复制链接</button>
+            <a class="detail-button" href="{{ detail_url }}">查看详情</a>
+        </div>
+    </div>
+</article>
+{% endmacro %}
 
-        <div class="hero-actions">
-            <a class="button" href="{{ url_for('activity.create_activity') }}">发布活动</a>
-            <a class="button button-secondary" href="{{ url_for('circle.circles') }}">浏览同好圈</a>
+<section class="home-intro">
+    <div class="container home-intro-inner">
+        <div>
+            <p class="eyebrow">Gatherly Activities</p>
+            <h1>发现附近值得参加的活动</h1>
+            <p>从兴趣出发，认识同频的人。近期精选活动已为你整理好。</p>
+        </div>
+        <a class="button" href="{{ url_for('activity.create_activity') }}">发布活动</a>
+    </div>
+</section>
+
+<section class="home-section recommended-section">
+    <div class="container">
+        <div class="home-section-heading">
+            <div>
+                <p class="eyebrow">Recommended</p>
+                <h2>近期推荐活动</h2>
+                <p>先看看近期最值得加入的线下体验。</p>
+            </div>
+            <a class="section-link" href="#discover">浏览全部活动 <span aria-hidden="true">&#8594;</span></a>
+        </div>
+        <div class="featured-strip">
+            <article class="featured-card featured-card-main">
+                <div>
+                    <span class="featured-label">本周精选</span>
+                    <h3>周末城市摄影散步</h3>
+                    <p>周六 15:00 · 徐汇滨江</p>
+                    <a href="#discover">查看活动</a>
+                </div>
+            </article>
+            <article class="featured-card featured-card-secondary">
+                <div>
+                    <span class="featured-label">热门报名</span>
+                    <h3>手冲咖啡入门体验</h3>
+                    <p>周日 10:30 · 静安咖啡实验室</p>
+                    <a href="#discover">查看活动</a>
+                </div>
+            </article>
         </div>
     </div>
 </section>
 
-<section class="section">
+<section class="home-section my-activities-section">
     <div class="container">
-        <div class="section-heading">
-            <p class="eyebrow">Featured Activities</p>
-            <h2>近期推荐活动</h2>
+        <div class="home-section-heading compact-heading">
+            <div>
+                <p class="eyebrow">My Activities</p>
+                <h2>我的活动</h2>
+            </div>
+        </div>
+        <div class="my-activities-panel">
+            <div class="home-tabs" role="tablist" aria-label="我的活动">
+                <button class="home-tab is-active" type="button" role="tab" aria-selected="true" data-home-tab="registered">已报名</button>
+                <button class="home-tab" type="button" role="tab" aria-selected="false" data-home-tab="favorited">已收藏</button>
+            </div>
+            <div class="home-tab-panel" data-home-tab-panel="registered">
+                <p>报名后的活动会集中展示在这里，方便你快速查看行程。</p>
+                {% if session.get("user_id") %}
+                <a class="section-link" href="{{ url_for('profile.joined_activities') }}">查看我的报名 <span aria-hidden="true">&#8594;</span></a>
+                {% else %}
+                <a class="section-link" href="{{ url_for('auth.login') }}">登录后查看报名 <span aria-hidden="true">&#8594;</span></a>
+                {% endif %}
+            </div>
+            <div class="home-tab-panel" data-home-tab-panel="favorited" hidden>
+                <p>收藏功能入口已预留，后续接入后端逻辑后将在这里同步展示。</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="home-section discover-section" id="discover">
+    <div class="container">
+        <div class="home-section-heading">
+            <div>
+                <p class="eyebrow">Discover Activities</p>
+                <h2>发现更多活动</h2>
+                <p>按时间和兴趣快速找到适合你的下一场活动。</p>
+            </div>
+        </div>
+
+        <div class="discover-toolbar" aria-label="活动时间筛选">
+            <button class="filter-pill is-active" type="button" data-time-filter="any">全部日期</button>
+            <button class="filter-pill" type="button" data-time-filter="today">今天</button>
+            <button class="filter-pill" type="button" data-time-filter="weekend">本周末</button>
+            <button class="filter-pill" type="button" data-time-filter="week">本周</button>
         </div>
 
         <section class="interest-section {% if expand_tags_by_default %}is-expanded{% endif %}" aria-labelledby="interest-title">
             <div class="interest-header">
-                <p class="eyebrow">Interest Tags</p>
-                <h2 class="interest-title" id="interest-title">发现兴趣</h2>
-                <p class="interest-subtitle">从小众兴趣开始，找到附近适合你的线下活动。</p>
+                <h3 class="interest-title" id="interest-title">按兴趣探索</h3>
+                <p class="interest-subtitle">点击分类即可筛选活动。</p>
             </div>
-
-            <div class="interest-tags">
-                <a class="interest-chip {% if not selected_tag %}is-active{% endif %}" href="{{ url_for('activity.index') }}" data-tag="all">全部活动</a>
+            <div class="interest-tags icon-category-nav">
+                <a class="interest-chip icon-category {% if not selected_tag %}is-active{% endif %}" href="{{ url_for('activity.index') }}" data-tag="all">
+                    <span aria-hidden="true">&#10024;</span><span>全部活动</span>
+                </a>
                 {% if interest_tags %}
+                {% set icons = ["&#128247;", "&#127939;", "&#9749;", "&#128214;", "&#127912;", "&#127925;", "&#127916;", "&#128205;", "&#127922;", "&#128187;", "&#127859;", "&#129309;"] %}
                 {% for tag in interest_tags %}
-                <a class="interest-chip {% if loop.index > visible_tag_count %}is-extra-tag{% endif %} {% if selected_tag == tag %}is-active{% endif %}" href="{{ url_for('activity.index', tag=tag) }}" data-tag="{{ tag }}">{{ tag }}</a>
+                <a class="interest-chip icon-category {% if loop.index > visible_tag_count %}is-extra-tag{% endif %} {% if selected_tag == tag %}is-active{% endif %}"
+                   href="{{ url_for('activity.index', tag=tag) }}" data-tag="{{ tag }}">
+                    <span aria-hidden="true">{{ icons[loop.index0]|safe }}</span><span>{{ tag }}</span>
+                </a>
                 {% endfor %}
                 {% else %}
                 <span class="interest-subtitle">暂无兴趣标签</span>
                 {% endif %}
             </div>
-
             {% if interest_tags|length > visible_tag_count %}
-            <button type="button"
-                    class="interest-toggle"
-                    data-tag-toggle
-                    aria-expanded="{{ 'true' if expand_tags_by_default else 'false' }}">
+            <button type="button" class="interest-toggle" data-tag-toggle aria-expanded="{{ 'true' if expand_tags_by_default else 'false' }}">
                 {{ '收起标签' if expand_tags_by_default else '展开更多兴趣' }}
             </button>
             {% endif %}
-
             <div class="filter-status">
                 {% if selected_tag %}
                 <span>当前正在浏览：{{ selected_tag }}</span>
@@ -65,45 +171,72 @@
             </div>
         </section>
 
-        {% if activities %}
-        <div class="card-grid">
-            {% for activity in activities %}
-            <a href="{{ url_for('activity.activity_detail', activity_id=activity.id) }}" class="activity-card" data-tags="{{ activity.tags|join(',') if activity.tags else activity.category }}">
-                <!-- 活动封面图 -->
-                <div class="card-image">
-                    <img src="{{ activity.image_url or url_for('static', filename='images/placeholder-activity.jpg') }}"
-                         alt="{{ activity.title }}"
-                         onerror="this.src='{{ url_for('static', filename='images/placeholder-activity.jpg') }}'">
-                </div>
-                <div class="card-body">
-                    <!-- 兴趣标签 -->
-                    <div class="card-tags">
-                        {% if activity.tags %}
-                            {% for tag in activity.tags %}
-                            <span class="tag">{{ tag }}</span>
-                            {% endfor %}
-                        {% elif activity.category %}
-                            <span class="tag">{{ activity.category }}</span>
-                        {% endif %}
-                    </div>
-
-                    <h3 class="card-title">{{ activity.title }}</h3>
-
-                    <div class="card-meta">
-                        <p class="meta-time">{{ activity.time }}</p>
-                        <p class="meta-location">{{ activity.location }}</p>
-                        <p class="meta-people">{{ activity.current_people }}/{{ activity.max_people }}人</p>
-                    </div>
-                </div>
-            </a>
+        <div class="card-grid activity-discovery-grid">
+            {% if activities %}
+                {% for activity in activities %}
+                    {{ activity_card(activity, url_for('activity.activity_detail', activity_id=activity.id)) }}
+                {% endfor %}
+            {% endif %}
+            {% set demo_activities = [
+                {"title": "周末城市摄影散步", "category": "影像摄影", "tags": ["影像摄影"], "time": "周六 15:00 - 17:30", "time_filter": "weekend", "location": "徐汇滨江 · 龙美术馆集合", "organizer": "城市取景器", "rating": "4.9", "attendees": 18},
+                {"title": "手冲咖啡风味入门体验", "category": "咖啡茶饮", "tags": ["咖啡茶饮"], "time": "周日 10:30 - 12:00", "time_filter": "weekend", "location": "静安区 · 咖啡实验室", "organizer": "一杯之间", "rating": "4.8", "attendees": 12},
+                {"title": "黄昏江畔轻跑小组", "category": "运动户外", "tags": ["运动户外"], "time": "今天 19:00 - 20:30", "time_filter": "today", "location": "浦东滨江 · 望江驿", "organizer": "周末轻运动", "rating": "4.7", "attendees": 24},
+                {"title": "独立电影放映与交流夜", "category": "观影戏剧", "tags": ["观影戏剧"], "time": "周五 19:30 - 22:00", "time_filter": "week", "location": "长宁区 · 小剧场", "organizer": "城市光影社", "rating": "4.9", "attendees": 31},
+                {"title": "零基础陶艺手捏工作坊", "category": "手作艺术", "tags": ["手作艺术"], "time": "周六 13:30 - 16:00", "time_filter": "weekend", "location": "愚园路 · 手作空间", "organizer": "慢慢做工作室", "rating": "4.8", "attendees": 9},
+                {"title": "新手友好桌游社交局", "category": "游戏桌游", "tags": ["游戏桌游"], "time": "周三 19:00 - 22:00", "time_filter": "week", "location": "人民广场 · 桌游馆", "organizer": "Gatherly 桌游组", "rating": "4.6", "attendees": 16}
+            ] %}
+            {% for activity in demo_activities %}
+                {{ activity_card(activity, url_for('activity.activity_detail', activity_id=1), true) }}
             {% endfor %}
         </div>
-        {% else %}
-        <div class="empty-state">
-            <p>暂无活动，快去发布第一个活动吧！</p>
-            <a class="button" href="{{ url_for('activity.create_activity') }}">发布活动</a>
+        <p class="no-match-tip" hidden>暂无匹配的活动，试试其他分类或时间。</p>
+    </div>
+</section>
+
+<section class="home-section circles-section">
+    <div class="container">
+        <div class="home-section-heading">
+            <div>
+                <p class="eyebrow">Popular Circles</p>
+                <h2>热门同好圈</h2>
+                <p>加入长期交流的兴趣社区，从一次活动认识更多同好。</p>
+            </div>
+            <a class="section-link" href="{{ url_for('circle.circles') }}">查看全部圈子 <span aria-hidden="true">&#8594;</span></a>
         </div>
-        {% endif %}
+        <div class="popular-circle-grid">
+            {% set home_circles = [
+                {"icon": "&#128247;", "name": "城市摄影散步圈", "tag": "影像摄影", "members": "328", "description": "每周一起探索城市取景点。"},
+                {"icon": "&#9749;", "name": "咖啡与慢生活", "tag": "咖啡茶饮", "members": "246", "description": "分享豆子、器具和线下体验。"},
+                {"icon": "&#127939;", "name": "周末轻运动", "tag": "运动户外", "members": "419", "description": "新手友好的跑步和户外活动。"}
+            ] %}
+            {% for circle in home_circles %}
+            <article class="popular-circle-card">
+                <span class="circle-card-icon" aria-hidden="true">{{ circle.icon|safe }}</span>
+                <span class="tag">{{ circle.tag }}</span>
+                <h3>{{ circle.name }}</h3>
+                <p>{{ circle.description }}</p>
+                <div><strong>{{ circle.members }}</strong> 位成员</div>
+                <a class="section-link" href="{{ url_for('circle.circles') }}">进入圈子 <span aria-hidden="true">&#8594;</span></a>
+            </article>
+            {% endfor %}
+        </div>
+    </div>
+</section>
+
+<section class="home-section trust-section">
+    <div class="container">
+        <div class="home-section-heading">
+            <div>
+                <p class="eyebrow">Trust & Safety</p>
+                <h2>平台信任机制与活动规则</h2>
+                <p>让每一次线下相遇更透明、更安心。</p>
+            </div>
+        </div>
+        <div class="trust-grid">
+            <article class="trust-card"><span aria-hidden="true">&#128737;</span><h3>真实参与反馈</h3><p>活动结束后，由实际参与者提交评分与反馈，帮助你判断活动质量。</p></article>
+            <article class="trust-card"><span aria-hidden="true">&#10003;</span><h3>明确报名规则</h3><p>报名人数、活动时间和地点清晰展示，请按约到场并尊重主办方安排。</p></article>
+            <article class="trust-card"><span aria-hidden="true">&#129309;</span><h3>友善社区约定</h3><p>保持尊重、注意安全。如遇不适当行为，请及时联系平台处理。</p></article>
+        </div>
     </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## 关联 Issue

Closes #请替换为UI-04对应的Issue编号

## 本次完成内容

- 取消或弱化原有大面积 Hero 首屏
- 将“近期推荐活动”提前到首页上方
- 重构首页顺序为：
  1. 顶部导航栏
  2. 近期推荐活动
  3. 我的活动：已报名 / 已收藏
  4. 活动发现区
  5. 热门同好圈
  6. 平台信任机制 / 活动规则说明
  7. 页脚
- 统一活动卡片样式
- 删除黑色测试卡片
- 活动卡片改为白底、圆角、轻阴影布局
- 活动卡片增加收藏按钮和分享 / 复制链接按钮样式占位
- 桌面端活动卡片 3 列展示
- 平板端活动卡片 2 列展示
- 移动端活动卡片 1 列展示

## 自测情况

- [ ] 本地可以正常运行
- [ ] 首页可以正常打开
- [ ] 近期推荐活动显示在页面上方
- [ ] 黑色测试卡片已删除或替换
- [ ] 活动卡片图片、标题、时间、地点、人数等信息显示正常
- [ ] 点击“查看详情”可以进入活动详情页
- [ ] 桌面端卡片布局正常
- [ ] 移动端卡片单列显示正常

## 主要修改文件

- app/templates/index.html
- app/static/css/style.css
- app/static/js/main.js

## 需要 Review 的重点

请重点检查：
- 首页结构是否符合新的页面顺序
- 活动卡片是否破坏原有活动数据展示
- 活动详情入口是否仍然可用
- 移动端是否存在横向溢出