### PR TITLE
style(UI-05): 将兴趣标签改为图标分类导航

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -3261,11 +3261,15 @@ textarea.form-input {
   margin-bottom: 14px;
   overflow-x: auto;
   padding-bottom: 2px;
+  scrollbar-width: thin;
 }
 
 .filter-pill {
+  display: inline-flex;
   flex: 0 0 auto;
   min-height: 38px;
+  align-items: center;
+  justify-content: center;
   padding: 0 15px;
   border: 1px solid var(--color-border);
   border-radius: 999px;
@@ -3285,6 +3289,7 @@ textarea.form-input {
 }
 
 .discover-section .interest-section {
+  overflow: hidden;
   padding: 18px;
   border-radius: 18px;
 }
@@ -3298,31 +3303,68 @@ textarea.form-input {
 }
 
 .icon-category-nav {
+  display: flex;
+  gap: 22px;
   flex-wrap: nowrap;
   overflow-x: auto;
-  padding-bottom: 8px;
+  overscroll-behavior-x: contain;
+  padding: 2px 0 8px;
   scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
 }
 
 .icon-category {
-  display: grid;
+  position: relative;
+  display: flex;
   flex: 0 0 86px;
-  min-height: 76px;
+  min-height: 82px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
   place-items: center;
   align-content: center;
-  gap: 4px;
-  padding: 8px 7px;
-  border-radius: 14px;
+  gap: 8px;
+  padding: 8px 2px 11px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--color-muted);
   text-align: center;
+  white-space: nowrap;
 }
 
-.icon-category span:first-child {
-  font-size: 23px;
+.icon-category:hover {
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-primary-dark);
+}
+
+.icon-category.is-active {
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-primary-dark);
+  font-weight: 800;
+}
+
+.icon-category.is-active::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--color-primary);
+  content: "";
+}
+
+.icon-category-symbol {
+  font-size: 25px;
   line-height: 1;
 }
 
-.icon-category span:last-child {
+.icon-category-label {
   font-size: 12px;
+  line-height: 1.25;
 }
 
 .activity-discovery-grid {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -21,13 +21,35 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 3000);
   });
 
-  // UI-04: 首页活动分类和时间筛选。
+  // UI-05: Meetup 风格分类导航和时间筛选。
   const discoverySection = document.querySelector(".discover-section");
-  const tagChips = discoverySection?.querySelectorAll(".interest-chip") || [];
+  const categoryLinks = discoverySection?.querySelectorAll("[data-category]") || [];
   const timeFilters = discoverySection?.querySelectorAll("[data-time-filter]") || [];
   const discoveryCards = discoverySection?.querySelectorAll(".discover-card") || [];
-  let activeTag = discoverySection?.querySelector(".interest-chip.is-active")?.dataset.tag || "all";
-  let activeTime = discoverySection?.querySelector("[data-time-filter].is-active")?.dataset.timeFilter || "any";
+  const filterParams = new URLSearchParams(window.location.search);
+  const requestedCategory = filterParams.get("category") || "all";
+  const requestedTime = filterParams.get("time") || "any";
+  let activeCategory = Array.from(categoryLinks).some(link => link.dataset.category === requestedCategory)
+    ? requestedCategory
+    : "all";
+  let activeTime = Array.from(timeFilters).some(filter => filter.dataset.timeFilter === requestedTime)
+    ? requestedTime
+    : "any";
+
+  const syncFilterUrl = () => {
+    const url = new URL(window.location.href);
+    if (activeCategory === "all") {
+      url.searchParams.delete("category");
+    } else {
+      url.searchParams.set("category", activeCategory);
+    }
+    if (activeTime === "any") {
+      url.searchParams.delete("time");
+    } else {
+      url.searchParams.set("time", activeTime);
+    }
+    window.history.replaceState({}, "", `${url.pathname}${url.search}${url.hash}`);
+  };
 
   const updateFilterStatus = () => {
     const filterStatus = discoverySection?.querySelector(".filter-status");
@@ -35,19 +57,26 @@ document.addEventListener("DOMContentLoaded", () => {
       return;
     }
 
-    const label = activeTag === "all" ? "全部活动" : activeTag;
+    const activeCategoryLink = discoverySection.querySelector(`[data-category="${activeCategory}"]`);
+    const activeTimeFilter = discoverySection.querySelector(`[data-time-filter="${activeTime}"]`);
+    const categoryLabel = activeCategoryLink?.textContent.trim() || "全部活动";
+    const timeLabel = activeTimeFilter?.textContent.trim() || "全部时间";
     filterStatus.innerHTML = "";
-    filterStatus.appendChild(document.createTextNode("当前正在浏览：" + label));
+    filterStatus.appendChild(document.createTextNode(`当前正在浏览：${categoryLabel} · ${timeLabel}`));
 
-    if (activeTag !== "all" || activeTime !== "any") {
+    if (activeCategory !== "all" || activeTime !== "any") {
       const clearLink = document.createElement("a");
       clearLink.href = "#";
       clearLink.className = "clear-filter-link";
       clearLink.textContent = "查看全部活动 / 清除筛选";
       clearLink.addEventListener("click", event => {
         event.preventDefault();
-        discoverySection.querySelector('.interest-chip[data-tag="all"]')?.click();
-        discoverySection.querySelector('[data-time-filter="any"]')?.click();
+        activeCategory = "all";
+        activeTime = "any";
+        categoryLinks.forEach(item => item.classList.toggle("is-active", item.dataset.category === "all"));
+        timeFilters.forEach(item => item.classList.toggle("is-active", item.dataset.timeFilter === "any"));
+        syncFilterUrl();
+        applyActivityFilters();
       });
       filterStatus.appendChild(clearLink);
     }
@@ -58,9 +87,15 @@ document.addEventListener("DOMContentLoaded", () => {
     discoveryCards.forEach(card => {
       const tags = (card.dataset.tags || "").split(",").map(tag => tag.trim());
       const time = card.dataset.time || "any";
-      const tagMatches = activeTag === "all" || tags.includes(activeTag);
-      const timeMatches = activeTime === "any" || time === activeTime;
-      const isVisible = tagMatches && timeMatches;
+      const categoryLink = discoverySection.querySelector(`[data-category="${activeCategory}"]`);
+      const categoryTags = (categoryLink?.dataset.filterTags || "").split(",").filter(Boolean);
+      const categoryMatches = activeCategory === "all"
+        || categoryTags.length === 0
+        || categoryTags.some(tag => tags.includes(tag));
+      const timeMatches = activeTime === "any"
+        || time === activeTime
+        || (activeTime === "week" && ["today", "tomorrow", "week", "weekend"].includes(time));
+      const isVisible = categoryMatches && timeMatches;
       card.style.display = isVisible ? "" : "none";
       if (isVisible) {
         visibleCount += 1;
@@ -74,48 +109,30 @@ document.addEventListener("DOMContentLoaded", () => {
     updateFilterStatus();
   };
 
-  tagChips.forEach(chip => {
-    chip.addEventListener("click", event => {
+  categoryLinks.forEach(link => {
+    link.addEventListener("click", event => {
       event.preventDefault();
-      activeTag = chip.dataset.tag || "all";
-      tagChips.forEach(item => item.classList.toggle("is-active", item === chip));
+      activeCategory = link.dataset.category || "all";
+      categoryLinks.forEach(item => item.classList.toggle("is-active", item === link));
+      syncFilterUrl();
       applyActivityFilters();
     });
   });
 
   timeFilters.forEach(filter => {
-    filter.addEventListener("click", () => {
+    filter.addEventListener("click", event => {
+      event.preventDefault();
       activeTime = filter.dataset.timeFilter || "any";
       timeFilters.forEach(item => item.classList.toggle("is-active", item === filter));
+      syncFilterUrl();
       applyActivityFilters();
     });
   });
 
-  const tagToggle = document.querySelector("[data-tag-toggle]");
-  if (tagToggle) {
-    tagToggle.addEventListener("click", () => {
-      const interestSection = tagToggle.closest(".interest-section");
-      if (!interestSection) {
-        return;
-      }
-
-      const isExpanded = interestSection.classList.toggle("is-expanded");
-      tagToggle.setAttribute("aria-expanded", String(isExpanded));
-      tagToggle.textContent = isExpanded ? "收起标签" : "展开更多兴趣";
-    });
-  }
-
-  // US-06-03: 清除筛选链接 — 无刷新跳转到全部
-  const clearFilterLink = discoverySection?.querySelector(".clear-filter-link");
-  if (clearFilterLink) {
-    clearFilterLink.addEventListener("click", (e) => {
-      e.preventDefault();
-      const allChip = discoverySection.querySelector('.interest-chip[data-tag="all"]');
-      if (allChip) {
-        allChip.click();
-      }
-    });
-  }
+  categoryLinks.forEach(item => item.classList.toggle("is-active", item.dataset.category === activeCategory));
+  timeFilters.forEach(item => item.classList.toggle("is-active", item.dataset.timeFilter === activeTime));
+  syncFilterUrl();
+  applyActivityFilters();
 
   const showShareToast = (message) => {
     let toast = document.querySelector(".share-toast");

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -67,7 +67,7 @@
                 <h2>近期推荐活动</h2>
                 <p>先看看近期最值得加入的线下体验。</p>
             </div>
-            <a class="section-link" href="#discover">浏览全部活动 <span aria-hidden="true">&#8594;</span></a>
+            <a class="section-link" href="#discover-events">浏览全部活动 <span aria-hidden="true">&#8594;</span></a>
         </div>
         <div class="featured-strip">
             <article class="featured-card featured-card-main">
@@ -75,7 +75,7 @@
                     <span class="featured-label">本周精选</span>
                     <h3>周末城市摄影散步</h3>
                     <p>周六 15:00 · 徐汇滨江</p>
-                    <a href="#discover">查看活动</a>
+                    <a href="#discover-events">查看活动</a>
                 </div>
             </article>
             <article class="featured-card featured-card-secondary">
@@ -83,7 +83,7 @@
                     <span class="featured-label">热门报名</span>
                     <h3>手冲咖啡入门体验</h3>
                     <p>周日 10:30 · 静安咖啡实验室</p>
-                    <a href="#discover">查看活动</a>
+                    <a href="#discover-events">查看活动</a>
                 </div>
             </article>
         </div>
@@ -118,7 +118,7 @@
     </div>
 </section>
 
-<section class="home-section discover-section" id="discover">
+<section class="home-section discover-section" id="discover-events">
     <div class="container">
         <div class="home-section-heading">
             <div>
@@ -129,45 +129,52 @@
         </div>
 
         <div class="discover-toolbar" aria-label="活动时间筛选">
-            <button class="filter-pill is-active" type="button" data-time-filter="any">全部日期</button>
-            <button class="filter-pill" type="button" data-time-filter="today">今天</button>
-            <button class="filter-pill" type="button" data-time-filter="weekend">本周末</button>
-            <button class="filter-pill" type="button" data-time-filter="week">本周</button>
+            <a class="filter-pill is-active" href="{{ url_for('activity.index') }}#discover-events" data-time-filter="any">全部时间</a>
+            <a class="filter-pill" href="{{ url_for('activity.index', time='today') }}#discover-events" data-time-filter="today">今天</a>
+            <a class="filter-pill" href="{{ url_for('activity.index', time='tomorrow') }}#discover-events" data-time-filter="tomorrow">明天</a>
+            <a class="filter-pill" href="{{ url_for('activity.index', time='week') }}#discover-events" data-time-filter="week">本周</a>
+            <a class="filter-pill" href="{{ url_for('activity.index', time='weekend') }}#discover-events" data-time-filter="weekend">本周末</a>
+            <a class="filter-pill" href="{{ url_for('activity.index', time='month') }}#discover-events" data-time-filter="month">本月</a>
         </div>
 
-        <section class="interest-section {% if expand_tags_by_default %}is-expanded{% endif %}" aria-labelledby="interest-title">
+        <section class="interest-section" aria-labelledby="interest-title">
             <div class="interest-header">
                 <h3 class="interest-title" id="interest-title">按兴趣探索</h3>
                 <p class="interest-subtitle">点击分类即可筛选活动。</p>
             </div>
-            <div class="interest-tags icon-category-nav">
-                <a class="interest-chip icon-category {% if not selected_tag %}is-active{% endif %}" href="{{ url_for('activity.index') }}" data-tag="all">
-                    <span aria-hidden="true">&#10024;</span><span>全部活动</span>
-                </a>
-                {% if interest_tags %}
-                {% set icons = ["&#128247;", "&#127939;", "&#9749;", "&#128214;", "&#127912;", "&#127925;", "&#127916;", "&#128205;", "&#127922;", "&#128187;", "&#127859;", "&#129309;"] %}
-                {% for tag in interest_tags %}
-                <a class="interest-chip icon-category {% if loop.index > visible_tag_count %}is-extra-tag{% endif %} {% if selected_tag == tag %}is-active{% endif %}"
-                   href="{{ url_for('activity.index', tag=tag) }}" data-tag="{{ tag }}">
-                    <span aria-hidden="true">{{ icons[loop.index0]|safe }}</span><span>{{ tag }}</span>
+            {% set meetup_categories = [
+                ("✨", "全部活动", "all", ""),
+                ("👥", "来自同好圈", "circles", ""),
+                ("🎉", "社交活动", "social", "咖啡茶饮,游戏桌游"),
+                ("🎨", "兴趣爱好", "hobbies", "影像摄影,阅读出版,手作艺术,音乐演出,观影戏剧,美食烘焙"),
+                ("⚽", "运动户外", "sports", "运动户外"),
+                ("🌲", "旅行探索", "travel", "城市探索"),
+                ("💼", "职业商业", "career", ""),
+                ("💻", "科技数码", "technology", "科技数码"),
+                ("🏙", "城市生活", "city-life", "城市探索,咖啡茶饮,美食烘焙"),
+                ("🎮", "游戏娱乐", "games", "游戏桌游,观影戏剧"),
+                ("🎵", "音乐舞蹈", "music", "音乐演出"),
+                ("💗", "支持成长", "support", ""),
+                ("🌿", "健康生活", "wellness", "运动户外"),
+                ("🖼", "艺术文化", "arts", "影像摄影,手作艺术,音乐演出,观影戏剧"),
+                ("🔬", "科学教育", "education", "科技数码,阅读出版"),
+                ("🐱", "宠物动物", "pets", ""),
+                ("📖", "阅读写作", "reading", "阅读出版"),
+                ("👨‍👩‍👧", "家庭亲子", "family", ""),
+                ("🤝", "公益志愿", "volunteering", "公益志愿")
+            ] %}
+            <div class="interest-tags icon-category-nav" role="navigation" aria-label="活动分类">
+                {% for icon, label, value, filter_tags in meetup_categories %}
+                <a class="interest-chip icon-category {% if value == 'all' %}is-active{% endif %}"
+                   href="{{ url_for('activity.index', category=value) if value != 'all' else url_for('activity.index') }}#discover-events"
+                   data-category="{{ value }}" data-filter-tags="{{ filter_tags }}">
+                    <span class="icon-category-symbol" aria-hidden="true">{{ icon }}</span>
+                    <span class="icon-category-label">{{ label }}</span>
                 </a>
                 {% endfor %}
-                {% else %}
-                <span class="interest-subtitle">暂无兴趣标签</span>
-                {% endif %}
             </div>
-            {% if interest_tags|length > visible_tag_count %}
-            <button type="button" class="interest-toggle" data-tag-toggle aria-expanded="{{ 'true' if expand_tags_by_default else 'false' }}">
-                {{ '收起标签' if expand_tags_by_default else '展开更多兴趣' }}
-            </button>
-            {% endif %}
             <div class="filter-status">
-                {% if selected_tag %}
-                <span>当前正在浏览：{{ selected_tag }}</span>
-                <a href="#" class="clear-filter-link">查看全部活动 / 清除筛选</a>
-                {% else %}
                 <span>当前正在浏览：全部活动</span>
-                {% endif %}
             </div>
         </section>
 


### PR DESCRIPTION
## 任务说明

参考 Meetup 活动发现页，将首页原来的兴趣标签 chip 改成 Meetup 风格图标分类导航，并在分类导航上方增加时间筛选器。

参考图：
- 图六：Meetup 活动发现页时间筛选器 + 图标分类导航

## 时间筛选器

在图标分类导航上方增加时间筛选器：

- 全部时间
- 今天
- 明天
- 本周
- 本周末
- 本月

## 图标分类

分类导航设置为横向滚动：

- ✨ 全部活动
- 👥 来自同好圈
- 🎉 社交活动
- 🎨 兴趣爱好
- ⚽ 运动户外
- 🌲 旅行探索
- 💼 职业商业
- 💻 科技数码
- 🏙 城市生活
- 🎮 游戏娱乐
- 🎵 音乐舞蹈
- 💗 支持成长
- 🌿 健康生活
- 🖼 艺术文化
- 🔬 科学教育
- 🐱 宠物动物
- 📖 阅读写作
- 👨‍👩‍👧 家庭亲子
- 🤝 公益志愿

## 样式要求

- 图标在上
- 中文名称在下
- 横向排列
- 当前选中项底部有下划线
- 当前选中项文字加粗
- 移动端可横向滚动
- 不要换行挤压页面

## 完成标准 Acceptance Criteria

- [ ] 原有普通 chip 标签改为图标分类导航
- [ ] 时间筛选器显示在分类导航上方
- [ ] 当前选中分类有底部下划线
- [ ] 当前选中分类文字加粗
- [ ] 移动端可以横向滑动
- [ ] 分类点击后尽量复用现有筛选逻辑
- [ ] 不修改数据库字段
- [ ] 不破坏已有活动卡片展示

## 建议修改文件

- app/templates/index.html
- app/static/css/style.css
- app/static/js/main.js

## 分支命名建议

ui/ui-05-category-time-filters