### PR TITLE
feat(US-19-01): 增加活动收藏和复制链接功能

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -25,6 +25,11 @@ class User(db.Model):
 
     activities = db.relationship("Activity", back_populates="organizer")
     registrations = db.relationship("Registration", back_populates="user")
+    activity_favorites = db.relationship(
+        "ActivityFavorite",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
     posts = db.relationship("Post", back_populates="user")
     reviews = db.relationship("Review", back_populates="user")
     activity_reviews = db.relationship("ActivityReview", back_populates="reviewer")
@@ -98,6 +103,11 @@ class Activity(db.Model):
 
     organizer = db.relationship("User", back_populates="activities")
     registrations = db.relationship("Registration", back_populates="activity")
+    favorites = db.relationship(
+        "ActivityFavorite",
+        back_populates="activity",
+        cascade="all, delete-orphan",
+    )
     reviews = db.relationship("Review", back_populates="activity")
     activity_reviews = db.relationship("ActivityReview", back_populates="activity")
     user_reviews = db.relationship("UserReview", back_populates="activity")
@@ -113,6 +123,24 @@ class Registration(db.Model):
 
     user = db.relationship("User", back_populates="registrations")
     activity = db.relationship("Activity", back_populates="registrations")
+
+
+class ActivityFavorite(db.Model):
+    __table_args__ = (
+        db.UniqueConstraint(
+            "user_id",
+            "activity_id",
+            name="uq_activity_favorite_user_activity",
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    activity_id = db.Column(db.Integer, db.ForeignKey("activity.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    user = db.relationship("User", back_populates="activity_favorites")
+    activity = db.relationship("Activity", back_populates="favorites")
 
 
 class Circle(db.Model):

--- a/app/routes/activity.py
+++ b/app/routes/activity.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, abort, render_template, request, session, redirect, url_for, flash
+from flask import Blueprint, abort, jsonify, render_template, request, session, redirect, url_for, flash
 from functools import wraps
 from datetime import datetime
 from sqlalchemy import func
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 from app.models import (
     db,
     Activity,
+    ActivityFavorite,
     ActivityReview,
     Registration,
     TrustScoreLog,
@@ -199,8 +200,23 @@ def index():
         .group_by(Registration.activity_id)
         .all()
     )
-    for act in filtered_activities:
+    for act in normalized_activities:
         act["current_people"] = reg_counts.get(act["id"], 0)
+
+    favorite_activity_ids = set()
+    favorite_activities = []
+    if "user_id" in session:
+        favorite_activity_ids = {
+            favorite.activity_id
+            for favorite in ActivityFavorite.query.filter_by(
+                user_id=session["user_id"]
+            ).all()
+        }
+        favorite_activities = [
+            activity
+            for activity in normalized_activities
+            if activity["id"] in favorite_activity_ids
+        ]
 
     return render_template(
         "index.html",
@@ -210,6 +226,8 @@ def index():
         interest_tags=interest_tags,
         selected_tag=selected_tag,
         visible_tag_count=visible_tag_count,
+        favorite_activity_ids=favorite_activity_ids,
+        favorite_activities=favorite_activities,
     )
 
 
@@ -227,6 +245,7 @@ def activity_detail(activity_id):
     rating_stats = _get_rating_stats(activity_id)
 
     user_registered = False
+    is_favorited = False
     user_attended = False
     has_rated = False
     can_rate = False
@@ -235,6 +254,9 @@ def activity_detail(activity_id):
     if "user_id" not in session:
         rating_notice = "请先登录后再评分。"
     else:
+        is_favorited = ActivityFavorite.query.filter_by(
+            user_id=session["user_id"], activity_id=activity_id
+        ).first() is not None
         registration = Registration.query.filter_by(
             user_id=session["user_id"], activity_id=activity_id
         ).first()
@@ -314,6 +336,7 @@ def activity_detail(activity_id):
         max_participants=max_participants,
         preparation=preparation,
         user_registered=user_registered,
+        is_favorited=is_favorited,
         has_rated=has_rated,
         can_rate=can_rate,
         rating_notice=rating_notice,
@@ -322,6 +345,48 @@ def activity_detail(activity_id):
         user_review_candidates=user_review_candidates,
         user_review_notice=user_review_notice,
     )
+
+
+@activity_bp.route("/activity/<int:activity_id>/favorite", methods=["POST"])
+def toggle_activity_favorite(activity_id):
+    if "user_id" not in session:
+        return jsonify(
+            {
+                "error": "login_required",
+                "login_url": url_for(
+                    "auth.login",
+                    next=url_for("activity.activity_detail", activity_id=activity_id),
+                ),
+            }
+        ), 401
+
+    activity = next((a for a in activities if a.get("id") == activity_id), None)
+    if activity is None:
+        abort(404)
+
+    favorite = ActivityFavorite.query.filter_by(
+        user_id=session["user_id"],
+        activity_id=activity_id,
+    ).first()
+    if favorite is not None:
+        db.session.delete(favorite)
+        is_favorited = False
+    else:
+        db.session.add(
+            ActivityFavorite(
+                user_id=session["user_id"],
+                activity_id=activity_id,
+            )
+        )
+        is_favorited = True
+
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        is_favorited = True
+
+    return jsonify({"is_favorited": is_favorited})
 
 
 @activity_bp.route("/activities/create")

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1136,6 +1136,40 @@ img {
   margin: 16px 0 24px;
 }
 
+.detail-secondary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: -10px 0 24px;
+}
+
+.detail-action-button {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-surface);
+  color: var(--color-primary-dark);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.detail-action-button:hover {
+  border-color: var(--color-primary);
+  background: #e8f0ed;
+}
+
+.detail-action-button.favorite-button.is-active {
+  border-color: #e8a6b1;
+  color: #e04f67;
+}
+
 /* 基础信息卡片 */
 .detail-info-card {
   border: none;
@@ -3253,6 +3287,28 @@ textarea.form-input {
 .home-tab-panel p {
   margin-bottom: 7px;
   color: var(--color-muted);
+}
+
+.favorite-activity-list {
+  display: grid;
+  gap: 8px;
+}
+
+.favorite-activity-item {
+  display: grid;
+  gap: 2px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #f7faf8;
+}
+
+.favorite-activity-item:hover {
+  background: #e8f0ed;
+}
+
+.favorite-activity-item span {
+  color: var(--color-muted);
+  font-size: 13px;
 }
 
 .discover-toolbar {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -186,12 +186,52 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  document.querySelectorAll("[data-favorite-placeholder]").forEach(button => {
-    button.addEventListener("click", () => {
-      const isActive = button.classList.toggle("is-active");
-      button.setAttribute("aria-pressed", String(isActive));
-      button.querySelector("span").innerHTML = isActive ? "&#9829;" : "&#9825;";
-      showShareToast(isActive ? "已添加到收藏预览" : "已取消收藏预览");
+  const syncFavoriteButtons = (activityId, isFavorited) => {
+    document.querySelectorAll(`[data-activity-favorite][data-activity-id="${activityId}"]`).forEach(button => {
+      button.classList.toggle("is-active", isFavorited);
+      button.setAttribute("aria-pressed", String(isFavorited));
+      const icon = button.querySelector("span[aria-hidden='true']");
+      const label = button.querySelector("[data-favorite-label]");
+      if (icon) {
+        icon.innerHTML = isFavorited ? "&#9829;" : "&#9825;";
+      }
+      if (label) {
+        label.textContent = isFavorited ? "已收藏" : "收藏活动";
+      }
+    });
+  };
+
+  document.querySelectorAll("[data-activity-favorite]").forEach(button => {
+    button.addEventListener("click", async () => {
+      if (!button.dataset.favoriteUrl) {
+        return;
+      }
+
+      button.disabled = true;
+      try {
+        const response = await fetch(button.dataset.favoriteUrl, {
+          method: "POST",
+          headers: { Accept: "application/json" },
+        });
+        const result = await response.json();
+        if (response.status === 401 && result.login_url) {
+          showShareToast("请先登录后再收藏活动");
+          window.setTimeout(() => {
+            window.location.href = result.login_url;
+          }, 500);
+          return;
+        }
+        if (!response.ok) {
+          throw new Error(result.error || "favorite request failed");
+        }
+
+        syncFavoriteButtons(button.dataset.activityId, result.is_favorited);
+        showShareToast(result.is_favorited ? "已收藏活动" : "已取消收藏");
+      } catch (error) {
+        showShareToast("收藏操作失败，请稍后重试");
+      } finally {
+        button.disabled = false;
+      }
     });
   });
 

--- a/app/templates/activity_detail.html
+++ b/app/templates/activity_detail.html
@@ -28,6 +28,25 @@
         </div>
 
         <h1 class="detail-title">{{ activity.title }}</h1>
+        <div class="detail-secondary-actions">
+            <button class="detail-action-button favorite-button {% if is_favorited %}is-active{% endif %}"
+                    type="button"
+                    aria-pressed="{{ 'true' if is_favorited else 'false' }}"
+                    data-activity-favorite
+                    data-activity-id="{{ activity.id }}"
+                    data-favorite-url="{{ url_for('activity.toggle_activity_favorite', activity_id=activity.id) }}"
+                    data-login-url="{{ url_for('auth.login', next=url_for('activity.activity_detail', activity_id=activity.id)) }}">
+                <span aria-hidden="true">{% if is_favorited %}&#9829;{% else %}&#9825;{% endif %}</span>
+                <span data-favorite-label>{% if is_favorited %}已收藏{% else %}收藏活动{% endif %}</span>
+            </button>
+            <button class="detail-action-button"
+                    type="button"
+                    data-activity-share
+                    data-share-url="{{ url_for('activity.activity_detail', activity_id=activity.id) }}">
+                <span aria-hidden="true">&#8599;</span>
+                <span>复制链接</span>
+            </button>
+        </div>
 
         <!-- Flash 消息 -->
         {% with messages = get_flashed_messages(with_categories=true) %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,7 +3,7 @@
 {% block title %}首页 - Gatherly{% endblock %}
 
 {% block content %}
-{% macro activity_card(activity, detail_url, demo=false) %}
+{% macro activity_card(activity, detail_url, favorite_activity_id, demo=false) %}
 <article class="activity-card discover-card" data-tags="{{ activity.tags|join(',') if activity.tags else activity.category }}" data-time="{{ activity.time_filter|default('any') }}">
     <div class="card-image {% if not activity.image_url %}is-placeholder-image{% endif %}">
         <img src="{{ activity.image_url or url_for('static', filename='images/placeholder-activity.jpg') }}"
@@ -11,8 +11,15 @@
              onerror="this.src='{{ url_for('static', filename='images/placeholder-activity.jpg') }}'">
         {% if not activity.image_url %}<span class="activity-image-placeholder" aria-hidden="true">&#10024;</span>{% endif %}
         <div class="card-image-actions">
-            <button class="card-icon-button favorite-button" type="button" aria-label="收藏 {{ activity.title }}" aria-pressed="false" data-favorite-placeholder>
-                <span aria-hidden="true">&#9825;</span>
+            <button class="card-icon-button favorite-button {% if favorite_activity_id in favorite_activity_ids %}is-active{% endif %}"
+                    type="button"
+                    aria-label="收藏 {{ activity.title }}"
+                    aria-pressed="{{ 'true' if favorite_activity_id in favorite_activity_ids else 'false' }}"
+                    data-activity-favorite
+                    data-activity-id="{{ favorite_activity_id }}"
+                    data-favorite-url="{{ url_for('activity.toggle_activity_favorite', activity_id=favorite_activity_id) }}"
+                    data-login-url="{{ url_for('auth.login', next=detail_url) }}">
+                <span aria-hidden="true">{% if favorite_activity_id in favorite_activity_ids %}&#9829;{% else %}&#9825;{% endif %}</span>
             </button>
             <button class="card-icon-button" type="button" aria-label="复制 {{ activity.title }} 的链接" data-activity-share data-share-url="{{ detail_url }}">
                 <span aria-hidden="true">&#8599;</span>
@@ -112,7 +119,23 @@
                 {% endif %}
             </div>
             <div class="home-tab-panel" data-home-tab-panel="favorited" hidden>
-                <p>收藏功能入口已预留，后续接入后端逻辑后将在这里同步展示。</p>
+                {% if session.get("user_id") %}
+                    {% if favorite_activities %}
+                    <div class="favorite-activity-list">
+                        {% for activity in favorite_activities %}
+                        <a class="favorite-activity-item" href="{{ url_for('activity.activity_detail', activity_id=activity.id) }}">
+                            <strong>{{ activity.title }}</strong>
+                            <span>{{ activity.time }} · {{ activity.location }}</span>
+                        </a>
+                        {% endfor %}
+                    </div>
+                    {% else %}
+                    <p>暂未收藏活动。点击活动卡片右上角的心形按钮即可收藏。</p>
+                    {% endif %}
+                {% else %}
+                <p>登录后即可收藏活动，并在这里集中查看。</p>
+                <a class="section-link" href="{{ url_for('auth.login') }}">登录后查看收藏 <span aria-hidden="true">&#8594;</span></a>
+                {% endif %}
             </div>
         </div>
     </div>
@@ -181,7 +204,7 @@
         <div class="card-grid activity-discovery-grid">
             {% if activities %}
                 {% for activity in activities %}
-                    {{ activity_card(activity, url_for('activity.activity_detail', activity_id=activity.id)) }}
+                    {{ activity_card(activity, url_for('activity.activity_detail', activity_id=activity.id), activity.id) }}
                 {% endfor %}
             {% endif %}
             {% set demo_activities = [
@@ -193,7 +216,7 @@
                 {"title": "新手友好桌游社交局", "category": "游戏桌游", "tags": ["游戏桌游"], "time": "周三 19:00 - 22:00", "time_filter": "week", "location": "人民广场 · 桌游馆", "organizer": "Gatherly 桌游组", "rating": "4.6", "attendees": 16}
             ] %}
             {% for activity in demo_activities %}
-                {{ activity_card(activity, url_for('activity.activity_detail', activity_id=1), true) }}
+                {{ activity_card(activity, url_for('activity.activity_detail', activity_id=1), 1, true) }}
             {% endfor %}
         </div>
         <p class="no-match-tip" hidden>暂无匹配的活动，试试其他分类或时间。</p>


### PR DESCRIPTION
## 用户故事

作为已登录用户，我想要在首页快速查看自己已报名和已收藏的活动，以便管理接下来要参加或感兴趣的活动。

## 功能说明

首页新增“我的活动”模块，包含两个 Tab：

- 已报名
- 已收藏

已报名逻辑：
- 用户点击“立即报名”后，该活动显示在“已报名”

已收藏逻辑：
- 用户点击活动卡片收藏按钮后，该活动显示在“已收藏”

空状态：

如果没有报名活动，显示：
- 标题：你还没有报名活动
- 描述：找到感兴趣的活动，和同频的人一起出发。
- 按钮：寻找活动

如果没有收藏活动，显示：
- 标题：你还没有收藏活动
- 描述：看到感兴趣的活动，可以点击卡片右上角收藏。
- 按钮：去发现活动

按钮点击后跳转到活动发现区：
- #discover-events

## 完成标准 Acceptance Criteria

- [ ] 首页有“我的活动”模块
- [ ] Tab 使用中文：已报名 / 已收藏
- [ ] 已报名列表读取当前用户报名记录
- [ ] 已收藏列表读取当前用户收藏记录
- [ ] 无报名活动时显示空状态
- [ ] 无收藏活动时显示空状态
- [ ] “寻找活动 / 去发现活动”跳转到活动发现区
- [ ] 未登录用户不显示私人活动数据，可显示登录引导
- [ ] 不破坏已有首页活动流和报名逻辑

## 建议修改文件

- app/routes/activity.py
- app/templates/index.html
- app/static/css/style.css
- app/static/js/main.js

## 分支命名建议

feat/us-19-02-home-my-events