### PR TITLE
feat(US-19-02): 首页展示已报名和已收藏活动

### DIFF
--- a/app/routes/activity.py
+++ b/app/routes/activity.py
@@ -173,6 +173,41 @@ def _get_rating_stats(activity_id):
     }
 
 
+def _format_home_activity_time(db_activity, fallback_activity):
+    if db_activity and db_activity.start_time:
+        return db_activity.start_time.strftime("%Y-%m-%d %H:%M")
+    return fallback_activity.get("time", "时间待定")
+
+
+def _build_home_activity_summary(activity_id, static_lookup, db_activity_map, reg_counts):
+    fallback_activity = dict(static_lookup.get(activity_id, {"id": activity_id}))
+    db_activity = db_activity_map.get(activity_id)
+    organizer_name = fallback_activity.get("organizer", "Gatherly 活动发起人")
+
+    if db_activity and db_activity.organizer:
+        organizer_name = db_activity.organizer.nickname or db_activity.organizer.username
+
+    if db_activity:
+        fallback_activity.update(
+            {
+                "id": db_activity.id,
+                "title": db_activity.title,
+                "location": db_activity.location or fallback_activity.get("location", "地点待定"),
+                "image_url": db_activity.image or fallback_activity.get("image_url"),
+                "organizer": organizer_name,
+                "time": _format_home_activity_time(db_activity, fallback_activity),
+            }
+        )
+
+    if not fallback_activity.get("category"):
+        fallback_activity["category"] = DEFAULT_ACTIVITY_TAG
+
+    summary = _with_official_activity_tags(fallback_activity)
+    summary["current_people"] = reg_counts.get(activity_id, 0)
+    summary["detail_url"] = url_for("activity.activity_detail", activity_id=activity_id)
+    return summary
+
+
 @activity_bp.route("/")
 def index():
     selected_tag = request.args.get("tag", "").strip()
@@ -205,17 +240,50 @@ def index():
 
     favorite_activity_ids = set()
     favorite_activities = []
+    registered_activities = []
     if "user_id" in session:
-        favorite_activity_ids = {
-            favorite.activity_id
-            for favorite in ActivityFavorite.query.filter_by(
-                user_id=session["user_id"]
-            ).all()
-        }
+        user_id = session["user_id"]
+        static_lookup = {activity["id"]: activity for activity in normalized_activities}
+
+        registration_rows = (
+            Registration.query.filter_by(user_id=user_id)
+            .order_by(Registration.register_time.desc())
+            .all()
+        )
+        favorite_rows = (
+            ActivityFavorite.query.filter_by(user_id=user_id)
+            .order_by(ActivityFavorite.created_at.desc())
+            .all()
+        )
+
+        favorite_activity_ids = {favorite.activity_id for favorite in favorite_rows}
+        user_activity_ids = {
+            row.activity_id for row in registration_rows
+        } | favorite_activity_ids
+        db_activity_map = {}
+        if user_activity_ids:
+            db_activity_map = {
+                activity.id: activity
+                for activity in Activity.query.filter(Activity.id.in_(user_activity_ids)).all()
+            }
+
+        registered_activities = [
+            _build_home_activity_summary(
+                row.activity_id,
+                static_lookup,
+                db_activity_map,
+                reg_counts,
+            )
+            for row in registration_rows
+        ]
         favorite_activities = [
-            activity
-            for activity in normalized_activities
-            if activity["id"] in favorite_activity_ids
+            _build_home_activity_summary(
+                row.activity_id,
+                static_lookup,
+                db_activity_map,
+                reg_counts,
+            )
+            for row in favorite_rows
         ]
 
     return render_template(
@@ -226,6 +294,7 @@ def index():
         interest_tags=interest_tags,
         selected_tag=selected_tag,
         visible_tag_count=visible_tag_count,
+        registered_activities=registered_activities,
         favorite_activity_ids=favorite_activity_ids,
         favorite_activities=favorite_activities,
     )

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -3289,26 +3289,70 @@ textarea.form-input {
   color: var(--color-muted);
 }
 
-.favorite-activity-list {
+.my-activity-list {
   display: grid;
-  gap: 8px;
+  gap: 10px;
 }
 
-.favorite-activity-item {
+.my-activity-item {
   display: grid;
-  gap: 2px;
-  padding: 10px 12px;
-  border-radius: 10px;
+  gap: 6px;
+  padding: 14px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
   background: #f7faf8;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
 
-.favorite-activity-item:hover {
-  background: #e8f0ed;
+.my-activity-item:hover {
+  border-color: #c7ddd6;
+  background: #eef6f3;
 }
 
-.favorite-activity-item span {
+.my-activity-item-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.my-activity-item strong {
+  color: var(--color-text);
+  font-size: 15px;
+}
+
+.my-activity-item span:last-child {
   color: var(--color-muted);
   font-size: 13px;
+}
+
+.my-activity-empty-state,
+.my-activity-login-guide {
+  display: grid;
+  justify-items: start;
+  gap: 10px;
+  padding: 22px;
+  border: 1px dashed var(--color-border);
+  border-radius: 16px;
+  background: #fbfaf7;
+}
+
+.my-activity-empty-state h3,
+.my-activity-login-guide h3 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 20px;
+}
+
+.my-activity-empty-state p,
+.my-activity-login-guide p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.favorite-activity-list {
+  display: grid;
+  gap: 10px;
 }
 
 .discover-toolbar {
@@ -3714,6 +3758,17 @@ textarea.form-input {
   .featured-card {
     min-height: 176px;
     padding: 20px;
+  }
+
+  .my-activity-item-main {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .my-activity-empty-state,
+  .my-activity-login-guide {
+    padding: 18px;
   }
 
   .discover-section .interest-section {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -201,6 +201,71 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   };
 
+  const favoriteActivityList = document.querySelector("[data-favorite-activity-list]");
+  const favoriteEmptyState = document.querySelector("[data-favorite-empty-state]");
+
+  const syncFavoritePanelState = () => {
+    if (!favoriteActivityList || !favoriteEmptyState) {
+      return;
+    }
+
+    const hasItems = favoriteActivityList.querySelector("[data-favorite-activity-item]") !== null;
+    favoriteActivityList.hidden = !hasItems;
+    favoriteEmptyState.hidden = hasItems;
+  };
+
+  const buildFavoriteActivityItem = (button) => {
+    const link = document.createElement("a");
+    link.className = "my-activity-item favorite-activity-item";
+    link.href = button.dataset.activityDetailUrl || "#";
+    link.dataset.favoriteActivityItem = button.dataset.activityId || "";
+
+    const main = document.createElement("div");
+    main.className = "my-activity-item-main";
+
+    const tag = document.createElement("span");
+    tag.className = "tag";
+    const card = button.closest(".discover-card");
+    const firstTag = card?.querySelector(".card-tags .tag");
+    tag.textContent = firstTag?.textContent.trim() || "城市探索";
+
+    const title = document.createElement("strong");
+    title.textContent = button.dataset.activityTitle || "活动";
+
+    main.appendChild(tag);
+    main.appendChild(title);
+
+    const meta = document.createElement("span");
+    const activityTime = button.dataset.activityTime || "时间待定";
+    const activityLocation = button.dataset.activityLocation || "地点待定";
+    meta.textContent = `${activityTime} · ${activityLocation}`;
+
+    link.appendChild(main);
+    link.appendChild(meta);
+    return link;
+  };
+
+  const syncFavoriteActivityList = (button, isFavorited) => {
+    if (!favoriteActivityList) {
+      return;
+    }
+
+    const activityId = button.dataset.activityId;
+    const existingItem = favoriteActivityList.querySelector(
+      `[data-favorite-activity-item="${activityId}"]`
+    );
+
+    if (isFavorited && !existingItem) {
+      favoriteActivityList.prepend(buildFavoriteActivityItem(button));
+    } else if (!isFavorited && existingItem) {
+      existingItem.remove();
+    }
+
+    syncFavoritePanelState();
+  };
+
+  syncFavoritePanelState();
+
   document.querySelectorAll("[data-activity-favorite]").forEach(button => {
     button.addEventListener("click", async () => {
       if (!button.dataset.favoriteUrl) {
@@ -226,6 +291,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
 
         syncFavoriteButtons(button.dataset.activityId, result.is_favorited);
+        syncFavoriteActivityList(button, result.is_favorited);
         showShareToast(result.is_favorited ? "已收藏活动" : "已取消收藏");
       } catch (error) {
         showShareToast("收藏操作失败，请稍后重试");

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,6 +17,10 @@
                     aria-pressed="{{ 'true' if favorite_activity_id in favorite_activity_ids else 'false' }}"
                     data-activity-favorite
                     data-activity-id="{{ favorite_activity_id }}"
+                    data-activity-title="{{ activity.title }}"
+                    data-activity-time="{{ activity.time }}"
+                    data-activity-location="{{ activity.location }}"
+                    data-activity-detail-url="{{ detail_url }}"
                     data-favorite-url="{{ url_for('activity.toggle_activity_favorite', activity_id=favorite_activity_id) }}"
                     data-login-url="{{ url_for('auth.login', next=detail_url) }}">
                 <span aria-hidden="true">{% if favorite_activity_id in favorite_activity_ids %}&#9829;{% else %}&#9825;{% endif %}</span>
@@ -111,30 +115,67 @@
                 <button class="home-tab" type="button" role="tab" aria-selected="false" data-home-tab="favorited">已收藏</button>
             </div>
             <div class="home-tab-panel" data-home-tab-panel="registered">
-                <p>报名后的活动会集中展示在这里，方便你快速查看行程。</p>
                 {% if session.get("user_id") %}
-                <a class="section-link" href="{{ url_for('profile.joined_activities') }}">查看我的报名 <span aria-hidden="true">&#8594;</span></a>
+                    {% if registered_activities %}
+                    <div class="my-activity-list">
+                        {% for activity in registered_activities %}
+                        <a class="my-activity-item" href="{{ activity.detail_url }}">
+                            <div class="my-activity-item-main">
+                                <span class="tag">{{ activity.category }}</span>
+                                <strong>{{ activity.title }}</strong>
+                            </div>
+                            <span>{{ activity.time }} / {{ activity.location }}</span>
+                        </a>
+                        {% endfor %}
+                    </div>
+                    {% else %}
+                    <div class="my-activity-empty-state">
+                        <h3>你还没有报名活动</h3>
+                        <p>找到感兴趣的活动，和同频的人一起出发。</p>
+                        <a class="button button-secondary" href="#discover-events">寻找活动</a>
+                    </div>
+                    {% endif %}
                 {% else %}
-                <a class="section-link" href="{{ url_for('auth.login') }}">登录后查看报名 <span aria-hidden="true">&#8594;</span></a>
+                    <div class="my-activity-login-guide">
+                        <h3>登录后查看你的活动</h3>
+                        <p>登录后可查看已报名活动，并持续追踪你的线下安排。</p>
+                        <a class="button" href="{{ url_for('auth.login', next=url_for('activity.index')) }}">立即登录</a>
+                    </div>
                 {% endif %}
             </div>
             <div class="home-tab-panel" data-home-tab-panel="favorited" hidden>
                 {% if session.get("user_id") %}
                     {% if favorite_activities %}
-                    <div class="favorite-activity-list">
+                    <div class="my-activity-list favorite-activity-list" data-favorite-activity-list>
                         {% for activity in favorite_activities %}
-                        <a class="favorite-activity-item" href="{{ url_for('activity.activity_detail', activity_id=activity.id) }}">
-                            <strong>{{ activity.title }}</strong>
-                            <span>{{ activity.time }} · {{ activity.location }}</span>
+                        <a class="my-activity-item favorite-activity-item" href="{{ activity.detail_url }}" data-favorite-activity-item="{{ activity.id }}">
+                            <div class="my-activity-item-main">
+                                <span class="tag">{{ activity.category }}</span>
+                                <strong>{{ activity.title }}</strong>
+                            </div>
+                            <span>{{ activity.time }} / {{ activity.location }}</span>
                         </a>
                         {% endfor %}
                     </div>
+                    <div class="my-activity-empty-state" data-favorite-empty-state hidden>
+                        <h3>你还没有收藏活动</h3>
+                        <p>看到感兴趣的活动，可以点击卡片右上角收藏。</p>
+                        <a class="button button-secondary" href="#discover-events">去发现活动</a>
+                    </div>
                     {% else %}
-                    <p>暂未收藏活动。点击活动卡片右上角的心形按钮即可收藏。</p>
+                    <div class="my-activity-list favorite-activity-list" data-favorite-activity-list hidden></div>
+                    <div class="my-activity-empty-state" data-favorite-empty-state>
+                        <h3>你还没有收藏活动</h3>
+                        <p>看到感兴趣的活动，可以点击卡片右上角收藏。</p>
+                        <a class="button button-secondary" href="#discover-events">去发现活动</a>
+                    </div>
                     {% endif %}
                 {% else %}
-                <p>登录后即可收藏活动，并在这里集中查看。</p>
-                <a class="section-link" href="{{ url_for('auth.login') }}">登录后查看收藏 <span aria-hidden="true">&#8594;</span></a>
+                    <div class="my-activity-login-guide">
+                        <h3>登录后查看你的收藏</h3>
+                        <p>看到感兴趣的活动后可以随时收藏，首页会集中展示在这里。</p>
+                        <a class="button" href="{{ url_for('auth.login', next=url_for('activity.index')) }}">立即登录</a>
+                    </div>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
## 用户故事

作为已登录用户，我想要在首页快速查看自己已报名和已收藏的活动，以便管理接下来要参加或感兴趣的活动。

## 功能说明

首页新增“我的活动”模块，包含两个 Tab：

- 已报名
- 已收藏

已报名逻辑：
- 用户点击“立即报名”后，该活动显示在“已报名”

已收藏逻辑：
- 用户点击活动卡片收藏按钮后，该活动显示在“已收藏”

空状态：

如果没有报名活动，显示：
- 标题：你还没有报名活动
- 描述：找到感兴趣的活动，和同频的人一起出发。
- 按钮：寻找活动

如果没有收藏活动，显示：
- 标题：你还没有收藏活动
- 描述：看到感兴趣的活动，可以点击卡片右上角收藏。
- 按钮：去发现活动

按钮点击后跳转到活动发现区：
- #discover-events

## 完成标准 Acceptance Criteria

- [ ] 首页有“我的活动”模块
- [ ] Tab 使用中文：已报名 / 已收藏
- [ ] 已报名列表读取当前用户报名记录
- [ ] 已收藏列表读取当前用户收藏记录
- [ ] 无报名活动时显示空状态
- [ ] 无收藏活动时显示空状态
- [ ] “寻找活动 / 去发现活动”跳转到活动发现区
- [ ] 未登录用户不显示私人活动数据，可显示登录引导
- [ ] 不破坏已有首页活动流和报名逻辑

## 建议修改文件

- app/routes/activity.py
- app/templates/index.html
- app/static/css/style.css
- app/static/js/main.js

## 分支命名建议

feat/us-19-02-home-my-events