### PR TITLE
style(UI-06): 重构活动详情页布局

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -3790,3 +3790,569 @@ textarea.form-input {
     gap: 12px;
   }
 }
+
+/* ============================================
+   Meetup-style activity detail page (UI-06)
+   ============================================ */
+
+.meetup-detail-page {
+  padding: 22px 0 150px;
+  background:
+    radial-gradient(circle at 82% 4%, rgba(215, 237, 230, 0.68), transparent 22rem),
+    linear-gradient(180deg, #ffffff 0, #f7f4ef 28rem);
+}
+
+.meetup-detail-organizer-banner {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin: 0 0 22px;
+  padding: 10px 14px 10px 18px;
+  border: 1px solid #cfe3dc;
+  border-radius: 16px;
+  background: linear-gradient(120deg, #e0f0eb, #f7eadc);
+}
+
+.meetup-detail-organizer-banner div:first-child {
+  display: grid;
+  gap: 1px;
+}
+
+.meetup-detail-organizer-banner strong {
+  color: var(--color-primary-dark);
+  font-size: 15px;
+}
+
+.meetup-detail-organizer-banner span {
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.meetup-detail-banner-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.meetup-detail-banner-actions button {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 24px;
+  line-height: 1;
+}
+
+.meetup-detail-banner-actions button:hover {
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--color-text);
+}
+
+.meetup-detail-back-link {
+  margin-bottom: 14px;
+}
+
+.meetup-detail-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 46px;
+  align-items: start;
+}
+
+.meetup-detail-main {
+  min-width: 0;
+}
+
+.meetup-detail-hero {
+  padding: 12px 0 28px;
+}
+
+.meetup-detail-title {
+  max-width: 760px;
+  margin: 15px 0 10px;
+  color: #20201e;
+  font-size: clamp(34px, 4.7vw, 56px);
+  letter-spacing: -1.8px;
+  line-height: 1.06;
+}
+
+.meetup-detail-host {
+  margin: 0 0 22px;
+  color: var(--color-muted);
+  font-size: 16px;
+}
+
+.meetup-detail-host strong {
+  color: var(--color-text);
+}
+
+.meetup-detail-circle-card {
+  display: flex;
+  max-width: 540px;
+  align-items: center;
+  gap: 13px;
+  padding: 13px;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.meetup-detail-circle-mark {
+  display: grid;
+  width: 52px;
+  height: 52px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 15px;
+  background: linear-gradient(135deg, var(--color-primary), #d58a5f);
+  color: #ffffff;
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.meetup-detail-circle-card div {
+  display: grid;
+}
+
+.meetup-detail-circle-card span,
+.meetup-detail-circle-card small {
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.meetup-detail-circle-card strong {
+  color: var(--color-text);
+  font-size: 15px;
+}
+
+.meetup-detail-section,
+.meetup-detail-rating-section {
+  margin-top: 18px;
+  padding: 25px;
+  border: 1px solid rgba(222, 216, 207, 0.86);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 5px 16px rgba(34, 34, 34, 0.05);
+}
+
+.meetup-detail-section h2 {
+  margin: 0 0 18px;
+  color: var(--color-text);
+  font-size: 25px;
+  letter-spacing: -0.5px;
+}
+
+.meetup-detail-content > h2::after {
+  display: block;
+  width: 46px;
+  height: 3px;
+  margin-top: 5px;
+  border-radius: 999px;
+  background: #d58a5f;
+  content: "";
+}
+
+.meetup-detail-copy-block + .meetup-detail-copy-block {
+  margin-top: 22px;
+}
+
+.meetup-detail-copy-block h3 {
+  margin: 0 0 7px;
+  color: var(--color-primary-dark);
+  font-size: 17px;
+}
+
+.meetup-detail-copy-block p {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 15px;
+  line-height: 1.85;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+}
+
+.meetup-detail-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.meetup-detail-section-heading h2 {
+  margin-bottom: 0;
+}
+
+.meetup-detail-section-heading span,
+.meetup-detail-muted {
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.meetup-detail-muted {
+  margin: 8px 0 0;
+}
+
+.meetup-detail-rating-section {
+  box-shadow: 0 5px 16px rgba(34, 34, 34, 0.05);
+}
+
+.meetup-detail-sidebar {
+  position: sticky;
+  top: 92px;
+  display: grid;
+  gap: 14px;
+}
+
+.meetup-detail-cover {
+  min-height: 220px;
+  overflow: hidden;
+  border: 7px solid #ffffff;
+  border-radius: 20px;
+  background: #d7ede6;
+  box-shadow: 0 9px 24px rgba(34, 34, 34, 0.13);
+}
+
+.meetup-detail-cover img {
+  width: 100%;
+  height: 240px;
+  object-fit: cover;
+}
+
+.meetup-detail-cover-placeholder {
+  display: grid;
+  min-height: 220px;
+  place-items: center;
+  align-content: center;
+  gap: 6px;
+  background:
+    radial-gradient(circle at 24% 24%, rgba(255, 255, 255, 0.72), transparent 5rem),
+    linear-gradient(135deg, #bcded5, #f2d7bd);
+  color: var(--color-primary-dark);
+}
+
+.meetup-detail-cover-placeholder span {
+  font-size: 52px;
+  line-height: 1;
+}
+
+.meetup-detail-side-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 4px 12px rgba(34, 34, 34, 0.05);
+}
+
+.meetup-detail-side-icon {
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.meetup-detail-side-card div:not(.meetup-detail-side-icon) {
+  display: grid;
+  gap: 2px;
+}
+
+.meetup-detail-side-card span {
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.meetup-detail-side-card strong {
+  color: var(--color-text);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.meetup-detail-capacity-card {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.meetup-detail-status {
+  color: var(--color-primary) !important;
+}
+
+.meetup-detail-status.is-registered {
+  color: #1565c0 !important;
+}
+
+.meetup-detail-status.is-closed {
+  color: #c62828 !important;
+}
+
+.meetup-detail-register-form {
+  width: 100%;
+}
+
+.meetup-detail-sidebar-registration {
+  margin-top: 0;
+}
+
+.meetup-detail-bottom-bar {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 20;
+  border-top: 1px solid rgba(222, 216, 207, 0.92);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 -7px 24px rgba(34, 34, 34, 0.1);
+  backdrop-filter: blur(14px);
+}
+
+.meetup-detail-bottom-inner {
+  display: grid;
+  min-height: 88px;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 26px;
+}
+
+.meetup-detail-bottom-summary {
+  display: grid;
+  min-width: 0;
+}
+
+.meetup-detail-bottom-summary span,
+.meetup-detail-bottom-meta span {
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.meetup-detail-bottom-summary strong {
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meetup-detail-bottom-meta {
+  display: grid;
+  text-align: right;
+}
+
+.meetup-detail-bottom-meta strong {
+  color: var(--color-primary-dark);
+  font-size: 17px;
+}
+
+.meetup-detail-bottom-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.meetup-detail-icon-button {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: #ffffff;
+  color: var(--color-primary-dark);
+  cursor: pointer;
+  font: inherit;
+  font-size: 20px;
+}
+
+.meetup-detail-icon-button:hover {
+  border-color: var(--color-primary);
+  background: #e8f0ed;
+}
+
+.meetup-detail-icon-button.favorite-button.is-active {
+  border-color: #e8a6b1;
+  color: #e04f67;
+}
+
+.meetup-detail-bottom-register,
+.meetup-detail-bottom-register form {
+  width: 184px;
+}
+
+.meetup-detail-bottom-register-button {
+  min-height: 48px;
+  border-radius: 999px;
+  font-size: 15px;
+}
+
+@media (max-width: 900px) {
+  .meetup-detail-layout {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .meetup-detail-sidebar {
+    position: static;
+    grid-row: 1;
+  }
+
+  .meetup-detail-sidebar-registration {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .meetup-detail-page {
+    padding: 12px 0 108px;
+  }
+
+  .meetup-detail-page > .container,
+  .meetup-detail-bottom-bar .container {
+    width: min(100% - 24px, 1120px);
+  }
+
+  .meetup-detail-organizer-banner {
+    align-items: flex-start;
+    gap: 10px;
+    padding: 11px 10px 11px 13px;
+  }
+
+  .meetup-detail-organizer-banner span {
+    display: none;
+  }
+
+  .meetup-detail-banner-actions {
+    gap: 3px;
+  }
+
+  .meetup-detail-banner-actions .button {
+    min-height: 34px;
+    padding: 0 11px;
+    font-size: 12px;
+  }
+
+  .meetup-detail-back-link {
+    margin-bottom: 7px;
+  }
+
+  .meetup-detail-hero {
+    padding: 9px 0 14px;
+  }
+
+  .meetup-detail-title {
+    margin-top: 10px;
+    font-size: 34px;
+    letter-spacing: -1.3px;
+  }
+
+  .meetup-detail-host {
+    margin-bottom: 15px;
+    font-size: 15px;
+  }
+
+  .meetup-detail-circle-card {
+    border-radius: 14px;
+  }
+
+  .meetup-detail-cover {
+    min-height: 188px;
+    border-width: 5px;
+    border-radius: 17px;
+  }
+
+  .meetup-detail-cover img {
+    height: 196px;
+  }
+
+  .meetup-detail-cover-placeholder {
+    min-height: 188px;
+  }
+
+  .meetup-detail-side-card {
+    padding: 14px;
+    border-radius: 14px;
+  }
+
+  .meetup-detail-capacity-card {
+    gap: 7px;
+  }
+
+  .meetup-detail-section,
+  .meetup-detail-rating-section {
+    margin-top: 13px;
+    padding: 18px;
+    border-radius: 15px;
+  }
+
+  .meetup-detail-section h2 {
+    font-size: 22px;
+  }
+
+  .meetup-detail-copy-block + .meetup-detail-copy-block {
+    margin-top: 18px;
+  }
+
+  .meetup-detail-copy-block p {
+    font-size: 14px;
+    line-height: 1.8;
+  }
+
+  .meetup-detail-bottom-inner {
+    display: flex;
+    min-height: 84px;
+    gap: 9px;
+  }
+
+  .meetup-detail-bottom-summary {
+    display: none;
+  }
+
+  .meetup-detail-bottom-meta {
+    flex: 0 0 auto;
+    text-align: left;
+  }
+
+  .meetup-detail-bottom-meta strong {
+    font-size: 15px;
+  }
+
+  .meetup-detail-bottom-meta span {
+    display: block;
+    max-width: 76px;
+    font-size: 11px;
+    line-height: 1.25;
+  }
+
+  .meetup-detail-bottom-actions {
+    min-width: 0;
+    flex: 1;
+    gap: 5px;
+  }
+
+  .meetup-detail-icon-button {
+    width: 40px;
+    height: 40px;
+    flex: 0 0 auto;
+  }
+
+  .meetup-detail-bottom-register,
+  .meetup-detail-bottom-register form {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .meetup-detail-bottom-register-button {
+    min-height: 48px;
+    padding: 0 11px;
+    font-size: 14px;
+    letter-spacing: 0;
+  }
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -401,6 +401,12 @@ document.addEventListener("DOMContentLoaded", () => {
     filterMembers();
   });
 
+  document.querySelectorAll("[data-organizer-banner-dismiss]").forEach(button => {
+    button.addEventListener("click", () => {
+      button.closest("[data-organizer-banner]")?.remove();
+    });
+  });
+
   const togglePanel = (button, panel, shouldOpen) => {
     if (!button || !panel) {
       return;

--- a/app/templates/activity_detail.html
+++ b/app/templates/activity_detail.html
@@ -2,284 +2,359 @@
 
 {% block title %}{{ activity.title }} - Gatherly{% endblock %}
 
+{% macro registration_button(extra_class="") %}
+    {% set activity_status = activity.status|default('', true)|lower %}
+    {% set event_ended = activity_status in ['ended', 'closed', 'completed', 'expired'] %}
+    {% set is_full = max_participants is not none and registration_count >= max_participants %}
+    {% if event_ended %}
+        <button class="btn btn-register btn-disabled {{ extra_class }}" type="button" disabled>活动已结束</button>
+    {% elif is_full %}
+        <button class="btn btn-register btn-disabled {{ extra_class }}" type="button" disabled>已满员</button>
+    {% elif user_registered %}
+        <button class="btn btn-register btn-disabled {{ extra_class }}" type="button" disabled>已报名</button>
+    {% elif session.get('user_id') %}
+        <form class="meetup-detail-register-form" action="{{ url_for('activity.register_activity', activity_id=activity.id) }}" method="post">
+            <button type="submit" class="btn btn-register {{ extra_class }}">立即报名</button>
+        </form>
+    {% else %}
+        {% set next_url = url_for('activity.activity_detail', activity_id=activity.id) %}
+        <a href="{{ url_for('auth.login', next=next_url) }}" class="btn btn-register {{ extra_class }}">登录后报名</a>
+    {% endif %}
+{% endmacro %}
+
 {% block content %}
+{% set activity_status = activity.status|default('', true)|lower %}
+{% set event_ended = activity_status in ['ended', 'closed', 'completed', 'expired'] %}
+{% set is_full = max_participants is not none and registration_count >= max_participants %}
+{% set remaining_places = max_participants - registration_count if max_participants is not none else none %}
+{% set organizer_name = activity.organizer|default('Gatherly 活动发起人', true) %}
+{% set circle_name = activity.circle_name|default(activity.circle|default(activity.category|default('城市兴趣同好圈', true), true), true) %}
+{% set activity_fee = activity.fee|default(0, true) %}
+{% set attendee_count = activity.attendee_count|default(registration_count, true) %}
+{% set comment_count = activity.comment_count|default(0, true) %}
 
-<section class="section">
-    <div class="container narrow-page">
-        <!-- 返回首页 -->
-        <a href="{{ url_for('activity.index') }}" class="back-link">← 返回活动列表</a>
+<section class="meetup-detail-page">
+    <div class="container">
+        <aside class="meetup-detail-organizer-banner" data-organizer-banner>
+            <div>
+                <strong>找到同频的人，一起把兴趣带到现场。</strong>
+                <span>成为活动发起人，让一次见面成为新的开始。</span>
+            </div>
+            <div class="meetup-detail-banner-actions">
+                <a class="button button-small" href="{{ url_for('activity.create_activity') }}">发起活动</a>
+                <button type="button" aria-label="关闭活动组织提示" data-organizer-banner-dismiss>&times;</button>
+            </div>
+        </aside>
 
-        <!-- 活动封面图 -->
-        {% if activity.image_url %}
-        <div class="detail-image">
-            <img src="{{ activity.image_url }}" alt="{{ activity.title }}">
+        <a href="{{ url_for('activity.index') }}" class="back-link meetup-detail-back-link">&larr; 返回活动列表</a>
+
+        <div class="meetup-detail-layout">
+            <main class="meetup-detail-main">
+                <header class="meetup-detail-hero">
+                    <div class="tag-group">
+                        {% if activity.tags %}
+                            {% for tag in activity.tags %}
+                                <span class="tag">{{ tag }}</span>
+                            {% endfor %}
+                        {% elif activity.category %}
+                            <span class="tag">{{ activity.category }}</span>
+                        {% endif %}
+                    </div>
+
+                    <h1 class="meetup-detail-title">{{ activity.title }}</h1>
+                    <p class="meetup-detail-host">主办方 <strong>{{ organizer_name }}</strong></p>
+
+                    <div class="meetup-detail-circle-card">
+                        <span class="meetup-detail-circle-mark" aria-hidden="true">G</span>
+                        <div>
+                            <span>所属同好圈</span>
+                            <strong>{{ circle_name }}</strong>
+                            <small>
+                                {% if rating_stats.count %}
+                                    {{ rating_stats.overall_avg }} <span class="rating-star" aria-hidden="true">&#9733;</span> · {{ rating_stats.count }} 条评分
+                                {% else %}
+                                    暂无评分
+                                {% endif %}
+                            </small>
+                        </div>
+                    </div>
+                </header>
+
+                <section class="meetup-detail-content meetup-detail-section">
+                    <h2>活动详情</h2>
+                    <div class="meetup-detail-copy-block">
+                        <h3>活动介绍</h3>
+                        <p>{{ activity.description|default('活动介绍待补充，欢迎关注后续更新。', true) }}</p>
+                    </div>
+                    <div class="meetup-detail-copy-block">
+                        <h3>你将体验什么</h3>
+                        <p>{{ activity.detail|default(activity.description|default('和同频伙伴一起参与线下活动，分享兴趣与真实体验。', true), true) }}</p>
+                    </div>
+                    <div class="meetup-detail-copy-block">
+                        <h3>适合人群</h3>
+                        <p>{{ activity.audience|default('对活动主题感兴趣，希望认识同好并参与线下交流的伙伴。', true) }}</p>
+                    </div>
+                    <div class="meetup-detail-copy-block">
+                        <h3>需要准备</h3>
+                        <p>{{ preparation|default('暂无特别准备事项，轻松来参加即可。', true) }}</p>
+                    </div>
+                    <div class="meetup-detail-copy-block">
+                        <h3>注意事项</h3>
+                        <p>{{ activity.notice|default('请按时到场。如计划有变，请及时调整报名安排，为其他参与者留出名额。', true) }}</p>
+                    </div>
+                </section>
+
+                <section class="meetup-detail-section">
+                    <div class="meetup-detail-section-heading">
+                        <h2>参与者</h2>
+                        <span>{{ attendee_count }} 人已报名</span>
+                    </div>
+                    <p class="meetup-detail-muted">报名成功后，你将和其他兴趣伙伴一起在线下见面。</p>
+                </section>
+
+                <section class="meetup-detail-section">
+                    <div class="meetup-detail-section-heading">
+                        <h2>评论</h2>
+                        <span>{{ comment_count }} 条</span>
+                    </div>
+                    <p class="meetup-detail-muted">暂无公开评论。活动结束后可以在评分区分享体验。</p>
+                </section>
+
+                <section class="rating-section meetup-detail-rating-section">
+                    <div class="rating-header">
+                        <h3>活动评分</h3>
+                        {% if rating_stats.count %}
+                            <span class="rating-count">{{ rating_stats.count }} 人已评分</span>
+                        {% endif %}
+                    </div>
+
+                    {% if rating_stats.count %}
+                    <div class="rating-summary">
+                        <div class="rating-overall">
+                            <span class="rating-overall-label">综合平均分</span>
+                            <strong>{{ rating_stats.overall_avg }}</strong>
+                            <span>/ 5</span>
+                        </div>
+                        <div class="rating-averages">
+                            <div class="rating-average-item"><span>组织能力</span><strong>{{ rating_stats.organization_avg }}</strong></div>
+                            <div class="rating-average-item"><span>场地环境</span><strong>{{ rating_stats.venue_avg }}</strong></div>
+                            <div class="rating-average-item"><span>内容质量</span><strong>{{ rating_stats.content_avg }}</strong></div>
+                            <div class="rating-average-item"><span>性价比</span><strong>{{ rating_stats.value_avg }}</strong></div>
+                            <div class="rating-average-item"><span>活动体验</span><strong>{{ rating_stats.experience_avg }}</strong></div>
+                        </div>
+                    </div>
+                    {% else %}
+                        <p class="rating-empty">暂无评分</p>
+                    {% endif %}
+
+                    {% if can_rate %}
+                    <form class="rating-form" method="post" action="{{ url_for('activity.submit_rating', activity_id=activity.id) }}">
+                        <div class="rating-dimension">
+                            <h4>组织能力</h4>
+                            <div class="star-rating" aria-label="组织能力评分">
+                                <input type="radio" id="org5" name="organization_score" value="5" required><label for="org5">&#9733;</label>
+                                <input type="radio" id="org4" name="organization_score" value="4"><label for="org4">&#9733;</label>
+                                <input type="radio" id="org3" name="organization_score" value="3"><label for="org3">&#9733;</label>
+                                <input type="radio" id="org2" name="organization_score" value="2"><label for="org2">&#9733;</label>
+                                <input type="radio" id="org1" name="organization_score" value="1"><label for="org1">&#9733;</label>
+                            </div>
+                        </div>
+                        <div class="rating-dimension">
+                            <h4>场地环境</h4>
+                            <div class="star-rating" aria-label="场地环境评分">
+                                <input type="radio" id="venue5" name="venue_score" value="5" required><label for="venue5">&#9733;</label>
+                                <input type="radio" id="venue4" name="venue_score" value="4"><label for="venue4">&#9733;</label>
+                                <input type="radio" id="venue3" name="venue_score" value="3"><label for="venue3">&#9733;</label>
+                                <input type="radio" id="venue2" name="venue_score" value="2"><label for="venue2">&#9733;</label>
+                                <input type="radio" id="venue1" name="venue_score" value="1"><label for="venue1">&#9733;</label>
+                            </div>
+                        </div>
+                        <div class="rating-dimension">
+                            <h4>内容质量</h4>
+                            <div class="star-rating" aria-label="内容质量评分">
+                                <input type="radio" id="content5" name="content_score" value="5" required><label for="content5">&#9733;</label>
+                                <input type="radio" id="content4" name="content_score" value="4"><label for="content4">&#9733;</label>
+                                <input type="radio" id="content3" name="content_score" value="3"><label for="content3">&#9733;</label>
+                                <input type="radio" id="content2" name="content_score" value="2"><label for="content2">&#9733;</label>
+                                <input type="radio" id="content1" name="content_score" value="1"><label for="content1">&#9733;</label>
+                            </div>
+                        </div>
+                        <div class="rating-dimension">
+                            <h4>性价比</h4>
+                            <div class="star-rating" aria-label="性价比评分">
+                                <input type="radio" id="value5" name="value_score" value="5" required><label for="value5">&#9733;</label>
+                                <input type="radio" id="value4" name="value_score" value="4"><label for="value4">&#9733;</label>
+                                <input type="radio" id="value3" name="value_score" value="3"><label for="value3">&#9733;</label>
+                                <input type="radio" id="value2" name="value_score" value="2"><label for="value2">&#9733;</label>
+                                <input type="radio" id="value1" name="value_score" value="1"><label for="value1">&#9733;</label>
+                            </div>
+                        </div>
+                        <div class="rating-dimension">
+                            <h4>活动体验</h4>
+                            <div class="star-rating" aria-label="活动体验评分">
+                                <input type="radio" id="exp5" name="experience_score" value="5" required><label for="exp5">&#9733;</label>
+                                <input type="radio" id="exp4" name="experience_score" value="4"><label for="exp4">&#9733;</label>
+                                <input type="radio" id="exp3" name="experience_score" value="3"><label for="exp3">&#9733;</label>
+                                <input type="radio" id="exp2" name="experience_score" value="2"><label for="exp2">&#9733;</label>
+                                <input type="radio" id="exp1" name="experience_score" value="1"><label for="exp1">&#9733;</label>
+                            </div>
+                        </div>
+                        <div class="rating-dimension">
+                            <h4>文字评价</h4>
+                            <textarea class="rating-comment" name="comment" rows="4" maxlength="1000" placeholder="分享本次活动体验"></textarea>
+                        </div>
+                        <button type="submit" class="btn rating-submit">提交评分</button>
+                    </form>
+                    {% elif rating_notice %}
+                        <p class="rating-notice">{{ rating_notice }}</p>
+                    {% endif %}
+                </section>
+
+                <section class="user-review-section meetup-detail-rating-section">
+                    <div class="rating-header">
+                        <h3>参与者互评</h3>
+                    </div>
+
+                    {% if can_user_review %}
+                        {% for candidate in user_review_candidates %}
+                            <div class="user-review-card">
+                                <div class="user-review-card-header">
+                                    <strong>{{ candidate.user.nickname or candidate.user.username }}</strong>
+                                    {% if candidate.has_reviewed %}
+                                        <span class="status-badge status-registered">已评价</span>
+                                    {% endif %}
+                                </div>
+
+                                {% if not candidate.has_reviewed %}
+                                <form class="rating-form user-review-form" method="post" action="{{ url_for('activity.submit_user_review', activity_id=activity.id) }}">
+                                    <input type="hidden" name="reviewee_id" value="{{ candidate.user.id }}">
+                                    {% set dimensions = [
+                                        ('punctuality_score', '守时'),
+                                        ('friendliness_score', '友善'),
+                                        ('communication_score', '沟通'),
+                                        ('reliability_score', '可靠'),
+                                        ('respect_score', '尊重'),
+                                        ('safety_score', '安全')
+                                    ] %}
+                                    {% for field, label in dimensions %}
+                                    <div class="rating-dimension">
+                                        <h4>{{ label }}</h4>
+                                        <div class="star-rating" aria-label="{{ label }}">
+                                            {% for score in [5, 4, 3, 2, 1] %}
+                                                {% set input_id = field ~ '-' ~ candidate.user.id ~ '-' ~ score %}
+                                                <input type="radio" id="{{ input_id }}" name="{{ field }}" value="{{ score }}" required>
+                                                <label for="{{ input_id }}">&#9733;</label>
+                                            {% endfor %}
+                                        </div>
+                                    </div>
+                                    {% endfor %}
+                                    <div class="rating-dimension">
+                                        <h4>补充评价</h4>
+                                        <textarea class="rating-comment" name="comment" rows="3" maxlength="1000" placeholder="可选：补充本次同行体验"></textarea>
+                                    </div>
+                                    <button type="submit" class="btn rating-submit">提交参与者评价</button>
+                                </form>
+                                {% endif %}
+                            </div>
+                        {% endfor %}
+                    {% elif user_review_notice %}
+                        <p class="rating-notice">{{ user_review_notice }}</p>
+                    {% endif %}
+                </section>
+            </main>
+
+            <aside class="meetup-detail-sidebar">
+                <div class="meetup-detail-cover">
+                    {% if activity.image_url %}
+                        <img src="{{ activity.image_url }}" alt="{{ activity.title }}">
+                    {% else %}
+                        <div class="meetup-detail-cover-placeholder" aria-label="活动图片待补充">
+                            <span aria-hidden="true">&#127914;</span>
+                            <strong>{{ activity.category|default('线下活动', true) }}</strong>
+                        </div>
+                    {% endif %}
+                </div>
+
+                <div class="meetup-detail-side-card">
+                    <div class="meetup-detail-side-icon" aria-hidden="true">&#128197;</div>
+                    <div>
+                        <span>活动时间</span>
+                        <strong>{{ activity.time|default('时间待确认', true) }}</strong>
+                    </div>
+                </div>
+
+                <div class="meetup-detail-side-card">
+                    <div class="meetup-detail-side-icon" aria-hidden="true">&#128205;</div>
+                    <div>
+                        <span>活动地点</span>
+                        <strong>{{ activity.location|default('地点待确认', true) }}</strong>
+                    </div>
+                </div>
+
+                <div class="meetup-detail-side-card meetup-detail-capacity-card">
+                    <div>
+                        <span>人数</span>
+                        <strong>{{ registration_count }}{% if max_participants is not none %} / {{ max_participants }}{% endif %} 人</strong>
+                    </div>
+                    <div>
+                        <span>费用</span>
+                        <strong>{% if activity_fee %}&yen;{{ activity_fee }}{% else %}免费{% endif %}</strong>
+                    </div>
+                    <div>
+                        <span>状态</span>
+                        {% if event_ended %}
+                            <strong class="meetup-detail-status is-closed">活动已结束</strong>
+                        {% elif is_full %}
+                            <strong class="meetup-detail-status is-closed">已满员</strong>
+                        {% elif user_registered %}
+                            <strong class="meetup-detail-status is-registered">已报名</strong>
+                        {% else %}
+                            <strong class="meetup-detail-status">可报名</strong>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="registration-action meetup-detail-sidebar-registration">
+                    {{ registration_button() }}
+                </div>
+            </aside>
         </div>
-        {% endif %}
+    </div>
+</section>
 
-        <!-- 兴趣标签 -->
-        <div class="tag-group">
-            {% if activity.tags %}
-                {% for tag in activity.tags %}
-                    <span class="tag">{{ tag }}</span>
-                {% endfor %}
-            {% elif activity.category %}
-                <span class="tag">{{ activity.category }}</span>
-            {% endif %}
+<aside class="meetup-detail-bottom-bar" aria-label="活动报名">
+    <div class="container meetup-detail-bottom-inner">
+        <div class="meetup-detail-bottom-summary">
+            <span>{{ activity.time|default('时间待确认', true) }}</span>
+            <strong>{{ activity.title }}</strong>
         </div>
-
-        <h1 class="detail-title">{{ activity.title }}</h1>
-        <div class="detail-secondary-actions">
-            <button class="detail-action-button favorite-button {% if is_favorited %}is-active{% endif %}"
+        <div class="meetup-detail-bottom-meta">
+            <strong>{% if activity_fee %}&yen;{{ activity_fee }}{% else %}免费{% endif %}</strong>
+            <span>{% if remaining_places is not none %}剩余 {{ [remaining_places, 0]|max }} 个名额{% else %}名额充足{% endif %}</span>
+        </div>
+        <div class="meetup-detail-bottom-actions">
+            <button class="meetup-detail-icon-button favorite-button {% if is_favorited %}is-active{% endif %}"
                     type="button"
+                    aria-label="收藏活动"
                     aria-pressed="{{ 'true' if is_favorited else 'false' }}"
                     data-activity-favorite
                     data-activity-id="{{ activity.id }}"
                     data-favorite-url="{{ url_for('activity.toggle_activity_favorite', activity_id=activity.id) }}"
                     data-login-url="{{ url_for('auth.login', next=url_for('activity.activity_detail', activity_id=activity.id)) }}">
                 <span aria-hidden="true">{% if is_favorited %}&#9829;{% else %}&#9825;{% endif %}</span>
-                <span data-favorite-label>{% if is_favorited %}已收藏{% else %}收藏活动{% endif %}</span>
+                <span class="sr-only" data-favorite-label>{% if is_favorited %}已收藏{% else %}收藏活动{% endif %}</span>
             </button>
-            <button class="detail-action-button"
+            <button class="meetup-detail-icon-button"
                     type="button"
+                    aria-label="分享活动"
                     data-activity-share
                     data-share-url="{{ url_for('activity.activity_detail', activity_id=activity.id) }}">
                 <span aria-hidden="true">&#8599;</span>
-                <span>复制链接</span>
             </button>
-        </div>
-
-        <!-- Flash 消息 -->
-        {% with messages = get_flashed_messages(with_categories=true) %}
-            {% if messages %}
-                {% for category, message in messages %}
-                    <div class="flash-message flash-{{ category }}">{{ message }}</div>
-                {% endfor %}
-            {% endif %}
-        {% endwith %}
-
-        <!-- 基础信息卡片 -->
-        <div class="detail-info-card">
-            <div class="detail-info-row">
-                <span class="detail-info-label">活动时间</span>
-                <span class="detail-info-value time-value">{{ activity.time }}</span>
+            <div class="meetup-detail-bottom-register">
+                {{ registration_button("meetup-detail-bottom-register-button") }}
             </div>
-            <div class="detail-info-row">
-                <span class="detail-info-label">活动地点</span>
-                <span class="detail-info-value location-value">{{ activity.location }}</span>
-            </div>
-            <div class="detail-info-row">
-                <span class="detail-info-label">活动人数</span>
-                <span class="detail-info-value people-value">
-                    已报名 {{ registration_count }} 人{% if max_participants is not none %} / 上限 {{ max_participants }} 人{% endif %}
-                </span>
-            </div>
-            <div class="detail-info-row">
-                <span class="detail-info-label">报名状态</span>
-                <span class="detail-info-value status-value">
-                    {% if max_participants is not none and registration_count >= max_participants %}
-                        <span class="status-badge status-full">已满员</span>
-                    {% elif user_registered %}
-                        <span class="status-badge status-registered">已报名</span>
-                    {% else %}
-                        <span class="status-badge status-open">可报名</span>
-                    {% endif %}
-                </span>
-            </div>
-        </div>
-
-        <!-- 报名按钮区域 -->
-        <div class="registration-action">
-            {% if max_participants is not none and registration_count >= max_participants %}
-                <button class="btn btn-register btn-disabled" disabled>已满员，无法报名</button>
-            {% elif user_registered %}
-                <button class="btn btn-register btn-disabled" disabled>您已报名该活动</button>
-            {% elif session.get('user_id') %}
-                <form action="{{ url_for('activity.register_activity', activity_id=activity.id) }}" method="post">
-                    <button type="submit" class="btn btn-register">立即报名</button>
-                </form>
-            {% else %}
-                {% set next_url = url_for('activity.activity_detail', activity_id=activity.id) %}
-                <a href="{{ url_for('auth.login', next=next_url) }}" class="btn btn-register">立即报名</a>
-            {% endif %}
-        </div>
-
-        <!-- 活动描述 -->
-        {% if activity.description or activity.detail %}
-        <div class="detail-description">
-            <h3>活动介绍</h3>
-            <p>{{ activity.description or activity.detail }}</p>
-        </div>
-        {% endif %}
-
-<!-- 活动准备事项 -->
-        <div class="detail-description">
-            <h3>活动准备事项</h3>
-            {% if preparation %}
-                <p class="preparation-content">{{ preparation }}</p>
-            {% else %}
-                <p class="preparation-empty">暂无活动准备事项</p>
-            {% endif %}
-        </div>
-
-        <!-- 多维度评分 -->
-        <div class="rating-section">
-            <div class="rating-header">
-                <h3>活动评分</h3>
-                {% if rating_stats.count %}
-                    <span class="rating-count">{{ rating_stats.count }} 人已评分</span>
-                {% endif %}
-            </div>
-
-            {% if rating_stats.count %}
-            <div class="rating-summary">
-                <div class="rating-overall">
-                    <span class="rating-overall-label">综合平均分</span>
-                    <strong>{{ rating_stats.overall_avg }}</strong>
-                    <span>/ 5</span>
-                </div>
-                <div class="rating-averages">
-                    <div class="rating-average-item">
-                        <span>组织能力</span>
-                        <strong>{{ rating_stats.organization_avg }}</strong>
-                    </div>
-                    <div class="rating-average-item">
-                        <span>场地环境</span>
-                        <strong>{{ rating_stats.venue_avg }}</strong>
-                    </div>
-                    <div class="rating-average-item">
-                        <span>内容质量</span>
-                        <strong>{{ rating_stats.content_avg }}</strong>
-                    </div>
-                    <div class="rating-average-item">
-                        <span>性价比</span>
-                        <strong>{{ rating_stats.value_avg }}</strong>
-                    </div>
-                    <div class="rating-average-item">
-                        <span>活动体验</span>
-                        <strong>{{ rating_stats.experience_avg }}</strong>
-                    </div>
-                </div>
-            </div>
-            {% else %}
-                <p class="rating-empty">暂无评分</p>
-            {% endif %}
-
-            {% if can_rate %}
-            <form class="rating-form" method="post" action="{{ url_for('activity.submit_rating', activity_id=activity.id) }}">
-                <div class="rating-dimension">
-                    <h4>组织能力</h4>
-                    <div class="star-rating" aria-label="组织能力评分">
-                        <input type="radio" id="org5" name="organization_score" value="5" required><label for="org5">&#9733;</label>
-                        <input type="radio" id="org4" name="organization_score" value="4"><label for="org4">&#9733;</label>
-                        <input type="radio" id="org3" name="organization_score" value="3"><label for="org3">&#9733;</label>
-                        <input type="radio" id="org2" name="organization_score" value="2"><label for="org2">&#9733;</label>
-                        <input type="radio" id="org1" name="organization_score" value="1"><label for="org1">&#9733;</label>
-                    </div>
-                </div>
-                <div class="rating-dimension">
-                    <h4>场地环境</h4>
-                    <div class="star-rating" aria-label="场地环境评分">
-                        <input type="radio" id="venue5" name="venue_score" value="5" required><label for="venue5">&#9733;</label>
-                        <input type="radio" id="venue4" name="venue_score" value="4"><label for="venue4">&#9733;</label>
-                        <input type="radio" id="venue3" name="venue_score" value="3"><label for="venue3">&#9733;</label>
-                        <input type="radio" id="venue2" name="venue_score" value="2"><label for="venue2">&#9733;</label>
-                        <input type="radio" id="venue1" name="venue_score" value="1"><label for="venue1">&#9733;</label>
-                    </div>
-                </div>
-                <div class="rating-dimension">
-                    <h4>内容质量</h4>
-                    <div class="star-rating" aria-label="内容质量评分">
-                        <input type="radio" id="content5" name="content_score" value="5" required><label for="content5">&#9733;</label>
-                        <input type="radio" id="content4" name="content_score" value="4"><label for="content4">&#9733;</label>
-                        <input type="radio" id="content3" name="content_score" value="3"><label for="content3">&#9733;</label>
-                        <input type="radio" id="content2" name="content_score" value="2"><label for="content2">&#9733;</label>
-                        <input type="radio" id="content1" name="content_score" value="1"><label for="content1">&#9733;</label>
-                    </div>
-                </div>
-                <div class="rating-dimension">
-                    <h4>性价比</h4>
-                    <div class="star-rating" aria-label="性价比评分">
-                        <input type="radio" id="value5" name="value_score" value="5" required><label for="value5">&#9733;</label>
-                        <input type="radio" id="value4" name="value_score" value="4"><label for="value4">&#9733;</label>
-                        <input type="radio" id="value3" name="value_score" value="3"><label for="value3">&#9733;</label>
-                        <input type="radio" id="value2" name="value_score" value="2"><label for="value2">&#9733;</label>
-                        <input type="radio" id="value1" name="value_score" value="1"><label for="value1">&#9733;</label>
-                    </div>
-                </div>
-                <div class="rating-dimension">
-                    <h4>活动体验</h4>
-                    <div class="star-rating" aria-label="活动体验评分">
-                        <input type="radio" id="exp5" name="experience_score" value="5" required><label for="exp5">&#9733;</label>
-                        <input type="radio" id="exp4" name="experience_score" value="4"><label for="exp4">&#9733;</label>
-                        <input type="radio" id="exp3" name="experience_score" value="3"><label for="exp3">&#9733;</label>
-                        <input type="radio" id="exp2" name="experience_score" value="2"><label for="exp2">&#9733;</label>
-                        <input type="radio" id="exp1" name="experience_score" value="1"><label for="exp1">&#9733;</label>
-                    </div>
-                </div>
-                <div class="rating-dimension">
-                    <h4>文字评价</h4>
-                    <textarea class="rating-comment" name="comment" rows="4" maxlength="1000" placeholder="分享本次活动体验"></textarea>
-                </div>
-                <button type="submit" class="btn rating-submit">提交评分</button>
-            </form>
-            {% elif rating_notice %}
-                <p class="rating-notice">{{ rating_notice }}</p>
-            {% endif %}
-        </div>
-
-        <div class="user-review-section">
-            <div class="rating-header">
-                <h3>Participant Reviews</h3>
-            </div>
-
-            {% if can_user_review %}
-                {% for candidate in user_review_candidates %}
-                    <div class="user-review-card">
-                        <div class="user-review-card-header">
-                            <strong>{{ candidate.user.nickname or candidate.user.username }}</strong>
-                            {% if candidate.has_reviewed %}
-                                <span class="status-badge status-registered">Reviewed</span>
-                            {% endif %}
-                        </div>
-
-                        {% if not candidate.has_reviewed %}
-                        <form class="rating-form user-review-form" method="post" action="{{ url_for('activity.submit_user_review', activity_id=activity.id) }}">
-                            <input type="hidden" name="reviewee_id" value="{{ candidate.user.id }}">
-
-                            {% set dimensions = [
-                                ('punctuality_score', 'Punctuality'),
-                                ('friendliness_score', 'Friendliness'),
-                                ('communication_score', 'Communication'),
-                                ('reliability_score', 'Reliability'),
-                                ('respect_score', 'Respect'),
-                                ('safety_score', 'Safety')
-                            ] %}
-                            {% for field, label in dimensions %}
-                            <div class="rating-dimension">
-                                <h4>{{ label }}</h4>
-                                <div class="star-rating" aria-label="{{ label }}">
-                                    {% for score in [5, 4, 3, 2, 1] %}
-                                        {% set input_id = field ~ '-' ~ candidate.user.id ~ '-' ~ score %}
-                                        <input type="radio" id="{{ input_id }}" name="{{ field }}" value="{{ score }}" required>
-                                        <label for="{{ input_id }}">&#9733;</label>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                            {% endfor %}
-
-                            <div class="rating-dimension">
-                                <h4>Comment</h4>
-                                <textarea class="rating-comment" name="comment" rows="3" maxlength="1000" placeholder="Optional notes about this participant"></textarea>
-                            </div>
-                            <button type="submit" class="btn rating-submit">Submit participant review</button>
-                        </form>
-                        {% endif %}
-                    </div>
-                {% endfor %}
-            {% elif user_review_notice %}
-                <p class="rating-notice">{{ user_review_notice }}</p>
-            {% endif %}
         </div>
     </div>
-</section>
+</aside>
 {% endblock %}


### PR DESCRIPTION
## 关联 Issue

Closes #204 

## 本次完成内容

- 重构活动详情页为 Meetup 风格详情布局
- 桌面端采用左文右图结构
- 左侧展示：
  - 活动标题
  - 主办方
  - 所属同好圈
  - 评分
  - 活动详情正文
  - 参与者 / 评论 / 评分
- 右侧展示：
  - 活动图片
  - 活动时间卡片
  - 活动地点卡片
  - 人数 / 费用 / 报名状态卡片
- 增加活动组织提示条：
  - 找到同频的人，一起把兴趣带到现场。
  - 发起活动
- 活动详情内容按小标题分区
- 增加底部固定报名栏
- 底部报名栏包含：
  - 活动时间
  - 活动标题
  - 费用
  - 剩余名额
  - 收藏按钮
  - 分享按钮
  - 报名按钮
- 移动端改为单列布局
- 移动端底部报名栏固定显示

## 报名按钮状态

- 未登录：登录后报名
- 未报名：立即报名
- 已报名：已报名
- 已满员：已满员
- 活动已结束：活动已结束

## 自测情况

- [ ] 本地可以正常运行
- [ ] 活动详情页可以正常打开
- [ ] 桌面端左文右图布局正常
- [ ] 右侧时间 / 地点 / 人数 / 费用卡片显示正常
- [ ] 底部固定报名栏显示正常
- [ ] 报名按钮状态显示正常
- [ ] 原有报名逻辑没有被破坏
- [ ] 原有评分逻辑没有被破坏
- [ ] 移动端单列布局正常
- [ ] 移动端底部报名栏没有遮挡主要内容

## 主要修改文件

- app/templates/activity_detail.html
- app/static/css/style.css
- app/static/js/main.js

## 需要 Review 的重点

请重点检查：
- 活动详情页是否仍然能正常报名
- 评分区域是否仍然可用
- 移动端底部固定报名栏是否影响阅读
- 是否存在模板变量不存在导致的报错