### PR TITLE
(UI-09): 优化活动创建页时间输入框字体样式

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1941,7 +1941,29 @@ img {
 }
 
 .form-input[type="datetime-local"] {
-    font-family: inherit;
+    font-family: "Microsoft YaHei", "PingFang SC", Arial, sans-serif;
+    font-size: 0.95rem;
+    color: #333;
+    letter-spacing: 0.02em;
+}
+
+.form-input[type="datetime-local"]::-webkit-datetime-edit {
+    font-family: "Microsoft YaHei", "PingFang SC", Arial, sans-serif;
+    color: #555;
+}
+
+.form-input[type="datetime-local"]::-webkit-datetime-edit-fields-wrapper {
+    font-family: "Microsoft YaHei", "PingFang SC", Arial, sans-serif;
+}
+
+.form-input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+    cursor: pointer;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+}
+
+.form-input[type="datetime-local"]:hover::-webkit-calendar-picker-indicator {
+    opacity: 1;
 }
 
 .form-input[type="number"] {


### PR DESCRIPTION
- 字体族统一为 Microsoft YaHei、PingFang SC、Arial、sans-serif
- 字号调整为 0.95rem，文字颜色 #333
- 增加 0.02em 字间距提升可读性
- 日历图标添加 hover 透明度过渡效果
- WebKit 日期编辑区域统一字体样式