### PR TITLE
feat(storage): upload user images to Cloudflare R2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,3 @@ gatherly_uploads_backup.zip
 
 # User uploads
 app/static/uploads/
-app/static/uploads/*
-!app/static/uploads/avatars/
-app/static/uploads/avatars/*
-!app/static/uploads/avatars/.gitkeep

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 from werkzeug.exceptions import RequestEntityTooLarge
 
 from app.models import db
+from app.services.storage import storage_url
 
 
 load_dotenv()
@@ -59,6 +60,7 @@ def create_app(test_config=None):
     db.init_app(app)
     migrate.init_app(app, db)
     csrf.init_app(app)
+    app.add_template_filter(storage_url, "asset_url")
 
     from app.routes.activity import activity_bp
     from app.routes.admin import admin_bp

--- a/app/routes/activity.py
+++ b/app/routes/activity.py
@@ -25,6 +25,7 @@ from app.models import (
     get_user_display_name,
     is_verified_merchant,
 )
+from app.services.storage import storage_url
 from app.utils.upload_utils import delete_saved_images, save_image_files, validate_image_files
 from app.utils.location_utils import locations_match, normalize_city
 
@@ -57,7 +58,7 @@ CANCEL_REASON_LABELS = {
 }
 TRUST_SCORE_THRESHOLD = 60
 ACTIVITY_IMAGE_MAX_BYTES = 800 * 1024
-ACTIVITY_IMAGE_UPLOAD_SUBDIR = os.path.join("images", "activities")
+ACTIVITY_IMAGE_UPLOAD_SUBDIR = "activities"
 ACTIVITY_CARD_AVATAR_LIMIT = 4
 ACTIVITY_ATTENDEE_DISPLAY_LIMIT = 7
 DEFAULT_ACTIVITY_TIMEZONE = "Asia/Shanghai"
@@ -1024,14 +1025,13 @@ def index():
             "name": circle.name,
             "tag": circle.tag,
             "description": _truncate_text(circle.description, 54),
-            "cover_url": url_for(
-                "static",
-                filename=(
-                    circle.cover_image
-                    if circle.cover_image
-                    and circle.cover_image.startswith(("images/circles/", "images/circle_covers/"))
-                    else "images/circle_covers/default.webp"
-                ),
+            "cover_url": storage_url(
+                circle.cover_image
+                if circle.cover_image
+                and circle.cover_image.startswith(
+                    ("http://", "https://", "/static/uploads/circles/", "images/circles/", "images/circle_covers/")
+                )
+                else "images/circle_covers/default.webp"
             ),
             "member_count": circle.member_count,
             "activity_count": circle_activity_counts.get(circle.id, 0),
@@ -1585,7 +1585,7 @@ def create_activity():
             timezone=timezone,
             max_participants=max_participants,
             initial_participants=0,
-            image=f"/static/{saved_paths[0]}",
+            image=saved_paths[0],
             fee=fee,
             tags=",".join(tags),
             circle_id=circle_id,

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -25,7 +25,7 @@ from app.utils.upload_utils import delete_saved_images, save_image_files, valida
 
 auth_bp = Blueprint("auth", __name__)
 MERCHANT_DOCUMENT_MAX_BYTES = 800 * 1024
-MERCHANT_DOCUMENT_UPLOAD_SUBDIR = os.path.join("uploads", "merchant-verifications")
+MERCHANT_DOCUMENT_UPLOAD_SUBDIR = "merchant-verifications"
 REGISTER_FORM_DRAFT_FIELDS = ("username", "email", "nickname", "city")
 EMAIL_CODE_SESSION_LIMIT_SECONDS = 60 * 60
 EMAIL_CODE_SESSION_LIMIT_MAX = 10

--- a/app/routes/circle.py
+++ b/app/routes/circle.py
@@ -15,10 +15,10 @@ POST_IMAGE_MAX_BYTES = 800 * 1024
 POST_IMAGE_MAX_COUNT = 3
 COMMENT_IMAGE_MAX_BYTES = 500 * 1024
 COMMENT_IMAGE_MAX_COUNT = 1
-POST_UPLOAD_SUBDIR = os.path.join("uploads", "posts")
-COMMENT_UPLOAD_SUBDIR = os.path.join("uploads", "comments")
+POST_UPLOAD_SUBDIR = "posts"
+COMMENT_UPLOAD_SUBDIR = "comments"
 CIRCLE_COVER_ASSET_SUBDIR = "images/circle_covers/"
-CIRCLE_COVER_UPLOAD_SUBDIR = os.path.join("images", "circles")
+CIRCLE_COVER_UPLOAD_SUBDIR = "circles"
 CIRCLE_COVER_UPLOAD_PREFIX = "images/circles/"
 CIRCLE_COVER_ALLOWED_SUBDIRS = (CIRCLE_COVER_ASSET_SUBDIR, CIRCLE_COVER_UPLOAD_PREFIX)
 DEFAULT_CIRCLE_COVER = f"{CIRCLE_COVER_ASSET_SUBDIR}default.webp"
@@ -116,7 +116,11 @@ def _is_official_default_cover(image_path):
 
 def _circle_cover_image(circle):
     cover_image = getattr(circle, "cover_image", None)
-    if not cover_image or not cover_image.startswith(CIRCLE_COVER_ALLOWED_SUBDIRS):
+    if not cover_image:
+        return DEFAULT_CIRCLE_COVER
+    if cover_image.startswith(("http://", "https://", "/static/uploads/circles/")):
+        return cover_image
+    if not cover_image.startswith(CIRCLE_COVER_ALLOWED_SUBDIRS):
         return DEFAULT_CIRCLE_COVER
     if os.path.splitext(cover_image)[1].lower() not in CIRCLE_COVER_EXTENSIONS:
         return DEFAULT_CIRCLE_COVER
@@ -162,7 +166,11 @@ def _save_circle_cover(file):
 def _is_uploaded_circle_cover(image_path):
     return bool(
         image_path
-        and image_path.startswith(CIRCLE_COVER_UPLOAD_PREFIX)
+        and (
+            image_path.startswith(CIRCLE_COVER_UPLOAD_PREFIX)
+            or image_path.startswith("/static/uploads/circles/")
+            or image_path.startswith(("http://", "https://"))
+        )
         and image_path not in _official_default_cover_paths()
         and os.path.splitext(image_path)[1].lower() in {".jpg", ".jpeg", ".png", ".webp"}
     )
@@ -171,10 +179,7 @@ def _is_uploaded_circle_cover(image_path):
 def _delete_uploaded_circle_cover(image_path):
     if not _is_uploaded_circle_cover(image_path):
         return
-    cover_dir = os.path.abspath(os.path.join(current_app.static_folder, CIRCLE_COVER_UPLOAD_PREFIX))
-    cover_path = os.path.abspath(os.path.join(current_app.static_folder, image_path))
-    if os.path.commonpath([cover_dir, cover_path]) == cover_dir:
-        delete_saved_images([image_path])
+    delete_saved_images([image_path])
 
 
 def _can_edit_circle_cover(user, circle):

--- a/app/routes/messages.py
+++ b/app/routes/messages.py
@@ -15,12 +15,13 @@ from app.models import (
     get_user_display_name,
     users_are_mutual_followers,
 )
+from app.services.storage import storage_url
 from app.utils.upload_utils import delete_saved_images, save_image_files, validate_image_files
 
 
 messages_bp = Blueprint("messages", __name__, url_prefix="/messages")
 
-MESSAGE_IMAGE_UPLOAD_SUBDIR = os.path.join("uploads", "messages")
+MESSAGE_IMAGE_UPLOAD_SUBDIR = "messages"
 MESSAGE_IMAGE_MAX_BYTES = 800 * 1024
 MESSAGE_TEXT_MAX_LENGTH = 2000
 
@@ -283,7 +284,7 @@ def _message_to_dict(message, current_user_id):
         "content": message.content or "",
         "message_type": message.message_type,
         "image_url": (
-            url_for("static", filename=message.image_path)
+            storage_url(message.image_path)
             if message.image_path
             else None
         ),

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -1,9 +1,7 @@
 from functools import wraps
-import os
 from urllib.parse import urlencode
-from uuid import uuid4
 
-from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, session, url_for
+from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
 from sqlalchemy import and_, or_, text
 from sqlalchemy.exc import IntegrityError, OperationalError
 
@@ -25,6 +23,7 @@ from app.models import (
     get_user_display_name,
 )
 from app.utils.location_utils import locations_match, update_user_detected_location
+from app.utils.upload_utils import delete_saved_images, save_image_files, validate_image_files
 
 profile_bp = Blueprint("profile", __name__, url_prefix="/profile")
 
@@ -33,12 +32,8 @@ PRIVATE_SCOPE = "private"
 SORT_OPTIONS = {"newest", "oldest"}
 BIO_MAX_LENGTH = 300
 INTERESTS_MAX_LENGTH = 500
-AVATAR_UPLOAD_SUBDIR = os.path.join("uploads", "avatars")
+AVATAR_UPLOAD_SUBDIR = "avatars"
 AVATAR_MAX_BYTES = 700 * 1024
-AVATAR_ALLOWED_TYPES = {
-    "image/jpeg": ("jpg", b"\xff\xd8\xff"),
-    "image/webp": ("webp", b"RIFF"),
-}
 UNKNOWN_LOCATION_LABELS = {"未知地区"}
 
 
@@ -142,46 +137,17 @@ def _normalize_interests(interests):
     return ", ".join(dict.fromkeys(_split_interests(interests)))
 
 
-def _avatar_upload_dir():
-    upload_dir = os.path.join(current_app.static_folder, AVATAR_UPLOAD_SUBDIR)
-    os.makedirs(upload_dir, exist_ok=True)
-    return upload_dir
-
-
 def _save_avatar(file):
     if not file or not file.filename:
         return None
 
-    expected = AVATAR_ALLOWED_TYPES.get(file.mimetype)
-    if expected is None:
-        raise ValueError("头像只支持 JPEG 或 WebP 格式。")
-
-    content = file.stream.read(AVATAR_MAX_BYTES + 1)
-    if not content:
-        raise ValueError("头像文件不能为空。")
-    if len(content) > AVATAR_MAX_BYTES:
-        raise ValueError("裁剪后的头像不能超过 700KB。")
-
-    extension, signature = expected
-    if not content.startswith(signature):
-        raise ValueError("头像文件内容与格式不匹配。")
-    if extension == "webp" and (len(content) < 12 or content[8:12] != b"WEBP"):
-        raise ValueError("头像文件内容与格式不匹配。")
-
-    filename = f"{uuid4().hex}.{extension}"
-    with open(os.path.join(_avatar_upload_dir(), filename), "wb") as avatar_file:
-        avatar_file.write(content)
-    return f"/static/{AVATAR_UPLOAD_SUBDIR.replace(os.sep, '/')}/{filename}"
+    validated_images = validate_image_files([file], max_count=1, max_bytes=AVATAR_MAX_BYTES)
+    saved_paths = save_image_files(validated_images, AVATAR_UPLOAD_SUBDIR)
+    return saved_paths[0] if saved_paths else None
 
 
 def _delete_managed_avatar(avatar_url):
-    prefix = f"/static/{AVATAR_UPLOAD_SUBDIR.replace(os.sep, '/')}/"
-    if not avatar_url or not avatar_url.startswith(prefix):
-        return
-
-    avatar_path = os.path.join(_avatar_upload_dir(), os.path.basename(avatar_url))
-    if os.path.isfile(avatar_path):
-        os.remove(avatar_path)
+    delete_saved_images([avatar_url] if avatar_url else [])
 
 
 def _safe_all(query):

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application service helpers."""

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -1,0 +1,207 @@
+import mimetypes
+import os
+from functools import lru_cache
+from uuid import uuid4
+
+from flask import current_app, url_for
+from werkzeug.utils import secure_filename
+
+
+R2_REQUIRED_ENV_VARS = (
+    "R2_ACCOUNT_ID",
+    "R2_BUCKET_NAME",
+    "R2_ACCESS_KEY_ID",
+    "R2_SECRET_ACCESS_KEY",
+    "R2_PUBLIC_BASE_URL",
+)
+
+ALLOWED_IMAGE_EXTENSIONS = {"jpg", "jpeg", "png", "webp", "gif"}
+ALLOWED_UPLOAD_DIRECTORIES = {
+    "avatars",
+    "posts",
+    "comments",
+    "activities",
+    "circles",
+    "messages",
+    "merchant-verifications",
+}
+
+UPLOAD_DIRECTORY_ALIASES = {
+    "uploads/avatars": "avatars",
+    "uploads/posts": "posts",
+    "uploads/comments": "comments",
+    "images/activities": "activities",
+    "images/circles": "circles",
+    "uploads/messages": "messages",
+    "uploads/merchant-verifications": "merchant-verifications",
+}
+
+CONTENT_TYPES = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "webp": "image/webp",
+    "gif": "image/gif",
+}
+
+
+def is_production_environment():
+    app_env = (
+        os.environ.get("APP_ENV")
+        or os.environ.get("FLASK_ENV")
+        or os.environ.get("ENV")
+        or ""
+    )
+    return app_env.strip().lower() in {"production", "prod"}
+
+
+def r2_config():
+    return {name: os.environ.get(name) for name in R2_REQUIRED_ENV_VARS}
+
+
+def missing_r2_config():
+    config = r2_config()
+    return [name for name, value in config.items() if not value]
+
+
+def r2_is_configured():
+    return not missing_r2_config()
+
+
+def require_r2_config():
+    missing = missing_r2_config()
+    if missing:
+        raise RuntimeError(
+            "Missing Cloudflare R2 environment variables: " + ", ".join(missing)
+        )
+    return r2_config()
+
+
+@lru_cache(maxsize=1)
+def r2_client():
+    import boto3
+
+    config = require_r2_config()
+    endpoint_url = f"https://{config['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com"
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        region_name="auto",
+        aws_access_key_id=config["R2_ACCESS_KEY_ID"],
+        aws_secret_access_key=config["R2_SECRET_ACCESS_KEY"],
+    )
+
+
+def public_base_url():
+    config = require_r2_config()
+    return config["R2_PUBLIC_BASE_URL"].rstrip("/")
+
+
+def normalize_upload_directory(directory):
+    normalized = str(directory or "").replace("\\", "/").strip("/")
+    normalized = UPLOAD_DIRECTORY_ALIASES.get(normalized, normalized)
+    if normalized not in ALLOWED_UPLOAD_DIRECTORIES:
+        raise ValueError(f"Unsupported upload directory: {directory}")
+    return normalized
+
+
+def extension_from_filename(filename):
+    safe_name = secure_filename(filename or "")
+    if "." not in safe_name:
+        raise ValueError("Image format is not supported.")
+    extension = safe_name.rsplit(".", 1)[1].lower()
+    if extension not in ALLOWED_IMAGE_EXTENSIONS:
+        raise ValueError("Image format is not supported.")
+    return extension
+
+
+def content_type_for_extension(extension):
+    return CONTENT_TYPES.get(extension) or mimetypes.types_map.get(
+        f".{extension}",
+        "application/octet-stream",
+    )
+
+
+def upload_file(file, directory, extension=None):
+    if not file or not file.filename:
+        return None
+
+    directory = normalize_upload_directory(directory)
+    extension = (extension or extension_from_filename(file.filename)).lower()
+    if extension not in ALLOWED_IMAGE_EXTENSIONS:
+        raise ValueError("Image format is not supported.")
+
+    filename = secure_filename(f"{uuid4().hex}.{extension}")
+    content_type = content_type_for_extension(extension)
+
+    if r2_is_configured():
+        key = f"{directory}/{filename}"
+        file.stream.seek(0)
+        r2_client().upload_fileobj(
+            file.stream,
+            os.environ["R2_BUCKET_NAME"],
+            key,
+            ExtraArgs={"ContentType": content_type},
+        )
+        return f"{public_base_url()}/{key}"
+
+    if is_production_environment():
+        require_r2_config()
+
+    local_dir = os.path.join(current_app.static_folder, "uploads", directory)
+    os.makedirs(local_dir, exist_ok=True)
+    file.stream.seek(0)
+    file.save(os.path.join(local_dir, filename))
+    return f"/static/uploads/{directory}/{filename}"
+
+
+def delete_stored_files(paths):
+    for path in paths:
+        if not path:
+            continue
+        if r2_is_configured() and path.startswith(f"{public_base_url()}/"):
+            key = path[len(public_base_url()) + 1 :]
+            try:
+                r2_client().delete_object(
+                    Bucket=os.environ["R2_BUCKET_NAME"],
+                    Key=key,
+                )
+            except Exception:
+                pass
+            continue
+        local_path = static_path_from_url(path)
+        if local_path and os.path.isfile(local_path):
+            try:
+                os.remove(local_path)
+            except OSError:
+                pass
+
+
+def storage_url(value):
+    if not value:
+        return ""
+    value = str(value)
+    if value.startswith(("http://", "https://", "data:")):
+        return value
+    if value.startswith("/static/"):
+        return value
+    if value.startswith("static/"):
+        return f"/{value}"
+    if value.startswith("app/static/"):
+        return f"/static/{value[len('app/static/'):]}"
+    return url_for("static", filename=value)
+
+
+def static_path_from_url(value):
+    if not value:
+        return None
+    value = str(value).replace("\\", "/")
+    if value.startswith("/static/"):
+        relative = value[len("/static/") :]
+    elif value.startswith("static/"):
+        relative = value[len("static/") :]
+    elif value.startswith("app/static/"):
+        relative = value[len("app/static/") :]
+    else:
+        return None
+    return os.path.join(current_app.static_folder, *relative.split("/"))

--- a/app/templates/admin_merchant_verifications.html
+++ b/app/templates/admin_merchant_verifications.html
@@ -28,7 +28,7 @@
             <td>{{ application.business_name }}</td>
             <td>
               {% if application.document_path %}
-              <a href="{{ url_for('static', filename=application.document_path) }}" target="_blank" rel="noopener">查看图片</a>
+              <a href="{{ application.document_path|asset_url }}" target="_blank" rel="noopener">查看图片</a>
               {% else %}-{% endif %}
             </td>
             <td>{{ application.reason or '-' }}</td>

--- a/app/templates/circle.html
+++ b/app/templates/circle.html
@@ -145,7 +145,7 @@
             {% for circle in circles %}
             <article class="activity-card circle-card circle-discovery-card discover-card" data-tags="{{ circle.tag or '兴趣爱好' }},{{ circle.name }}" data-time="any">
                 <a class="circle-card-cover" href="{{ url_for('circle.circle_detail', circle_id=circle.id) }}">
-                    <img src="{{ url_for('static', filename=circle.cover_image_url) }}" alt="{{ circle.name }} cover">
+                    <img src="{{ circle.cover_image_url|asset_url }}" alt="{{ circle.name }} cover">
                     <span class="circle-card-cover-overlay"></span>
                     <span class="circle-card-cover-content">
                         <span class="card-tags">

--- a/app/templates/circle_detail.html
+++ b/app/templates/circle_detail.html
@@ -65,8 +65,8 @@
     {% if comment.images %}
     <div class="circle-image-grid comment-image-grid">
         {% for image in comment.images %}
-        <a href="{{ url_for('static', filename=image.image_path) }}" target="_blank" rel="noopener">
-            <img src="{{ url_for('static', filename=image.image_path) }}" alt="评论图片 {{ loop.index }}">
+        <a href="{{ image.image_path|asset_url }}" target="_blank" rel="noopener">
+            <img src="{{ image.image_path|asset_url }}" alt="评论图片 {{ loop.index }}">
         </a>
         {% endfor %}
     </div>
@@ -150,7 +150,7 @@
 
         <header class="circle-detail-hero">
             <div class="circle-detail-cover">
-                <img src="{{ url_for('static', filename=circle.cover_image_url) }}" alt="{{ circle.name }} cover">
+                <img src="{{ circle.cover_image_url|asset_url }}" alt="{{ circle.name }} cover">
                 <span class="circle-detail-cover-overlay"></span>
                 <div class="circle-cover-badges">
                     {% if circle.is_system %}<span class="tag circle-official-tag">官方圈子</span>{% endif %}
@@ -287,7 +287,7 @@
                         {% for activity in upcoming_activities %}
                         <a class="circle-related-activity-card" href="{{ url_for('activity.activity_detail', activity_id=activity.id) }}">
                             <span class="circle-event-image">
-                                <img src="{{ url_for('static', filename=activity.image) }}" alt="{{ activity.title }}">
+                                <img src="{{ activity.image|asset_url }}" alt="{{ activity.title }}">
                                 <span class="circle-event-save" aria-hidden="true">♡</span>
                             </span>
                             <span class="tag">{{ activity.category }}</span>
@@ -309,7 +309,7 @@
                         {% for activity in past_activities %}
                         <a class="circle-related-activity-card" href="{{ url_for('activity.activity_detail', activity_id=activity.id) }}">
                             <span class="circle-event-image">
-                                <img src="{{ url_for('static', filename=activity.image) }}" alt="{{ activity.title }}">
+                                <img src="{{ activity.image|asset_url }}" alt="{{ activity.title }}">
                                 <span class="circle-event-save" aria-hidden="true">♡</span>
                             </span>
                             <span class="tag">{{ activity.category }}</span>
@@ -345,7 +345,7 @@
                         {% for item in photo_items %}
                         <div class="circle-photo-item">
                             <a href="#post-{{ item.post.id }}">
-                                <img src="{{ url_for('static', filename=item.image.image_path) }}" alt="{{ item.post.title }} 图片">
+                                <img src="{{ item.image.image_path|asset_url }}" alt="{{ item.post.title }} 图片">
                             </a>
                             {% if item.can_delete %}
                             <form method="POST" action="{{ url_for('circle.delete_post_image', image_id=item.image.id) }}" onsubmit="return confirm('确定删除这张照片吗？');">
@@ -412,8 +412,8 @@
                                 {% if post.images %}
                                 <div class="circle-image-grid">
                                     {% for image in post.images %}
-                                    <a href="{{ url_for('static', filename=image.image_path) }}" target="_blank" rel="noopener">
-                                        <img src="{{ url_for('static', filename=image.image_path) }}" alt="{{ post.title }} 图片 {{ loop.index }}">
+                                    <a href="{{ image.image_path|asset_url }}" target="_blank" rel="noopener">
+                                        <img src="{{ image.image_path|asset_url }}" alt="{{ post.title }} 图片 {{ loop.index }}">
                                     </a>
                                     {% endfor %}
                                 </div>

--- a/app/templates/messages.html
+++ b/app/templates/messages.html
@@ -104,8 +104,8 @@
           <article class="message-bubble {% if message.sender_id == session.get('user_id') %}is-mine{% endif %}" data-message-id="{{ message.id }}">
             <div class="message-bubble-inner">
               {% if message.image_path %}
-              <a href="{{ url_for('static', filename=message.image_path) }}" target="_blank" rel="noopener">
-                <img src="{{ url_for('static', filename=message.image_path) }}" alt="私信图片">
+              <a href="{{ message.image_path|asset_url }}" target="_blank" rel="noopener">
+                <img src="{{ message.image_path|asset_url }}" alt="私信图片">
               </a>
               {% endif %}
               {% if message.content %}<p>{{ message.content }}</p>{% endif %}

--- a/app/templates/my_groups.html
+++ b/app/templates/my_groups.html
@@ -56,7 +56,7 @@
         {% set group = membership.circle %}
         <a class="my-group-card" href="{{ url_for('circle.circle_detail', circle_id=group.id) }}">
           <span class="my-group-cover">
-            <img src="{{ url_for('static', filename=group.cover_image_url) }}" alt="{{ group.name }}">
+            <img src="{{ group.cover_image_url|asset_url }}" alt="{{ group.name }}">
           </span>
           <span class="my-group-copy">
             <strong>{{ group.name }}</strong>
@@ -84,7 +84,7 @@
         {% set group = membership.circle %}
         <a class="my-group-card" href="{{ url_for('circle.circle_detail', circle_id=group.id) }}">
           <span class="my-group-cover">
-            <img src="{{ url_for('static', filename=group.cover_image_url) }}" alt="{{ group.name }}">
+            <img src="{{ group.cover_image_url|asset_url }}" alt="{{ group.name }}">
           </span>
           <span class="my-group-copy">
             <strong>{{ group.name }}</strong>

--- a/app/utils/upload_utils.py
+++ b/app/utils/upload_utils.py
@@ -1,11 +1,10 @@
-import os
-from uuid import uuid4
-
-from flask import current_app
 from werkzeug.utils import secure_filename
 
-
-ALLOWED_IMAGE_EXTENSIONS = {"jpg", "jpeg", "png", "webp"}
+from app.services.storage import (
+    ALLOWED_IMAGE_EXTENSIONS,
+    delete_stored_files,
+    upload_file,
+)
 
 
 def _content_matches_extension(content, extension):
@@ -19,6 +18,8 @@ def _content_matches_extension(content, extension):
             and content.startswith(b"RIFF")
             and content[8:12] == b"WEBP"
         )
+    if extension == "gif":
+        return content.startswith((b"GIF87a", b"GIF89a"))
     return False
 
 
@@ -31,11 +32,11 @@ def validate_image_files(files, max_count, max_bytes):
     for file in selected_files:
         original_filename = secure_filename(file.filename)
         if "." not in original_filename:
-            raise ValueError("图片格式不支持，请上传 jpg、jpeg、png 或 webp 图片。")
+            raise ValueError("图片格式不支持，请上传 jpg、jpeg、png、webp 或 gif 图片。")
 
         extension = original_filename.rsplit(".", 1)[1].lower()
         if extension not in ALLOWED_IMAGE_EXTENSIONS:
-            raise ValueError("图片格式不支持，请上传 jpg、jpeg、png 或 webp 图片。")
+            raise ValueError("图片格式不支持，请上传 jpg、jpeg、png、webp 或 gif 图片。")
 
         content = file.stream.read(max_bytes)
         file.stream.seek(0)
@@ -52,16 +53,14 @@ def validate_image_files(files, max_count, max_bytes):
 
 
 def save_image_files(validated_files, upload_subdir):
-    upload_dir = os.path.join(current_app.static_folder, upload_subdir)
-    os.makedirs(upload_dir, exist_ok=True)
-
     saved_paths = []
     try:
         for file, extension in validated_files:
-            filename = secure_filename(f"{uuid4().hex}.{extension}")
-            file.save(os.path.join(upload_dir, filename))
-            saved_paths.append(f"{upload_subdir.replace(os.sep, '/')}/{filename}")
-    except OSError as exc:
+            saved_paths.append(upload_file(file, upload_subdir, extension=extension))
+    except RuntimeError as exc:
+        delete_saved_images(saved_paths)
+        raise ValueError(str(exc)) from exc
+    except Exception as exc:
         delete_saved_images(saved_paths)
         raise ValueError("图片保存失败，请稍后重试。") from exc
 
@@ -69,10 +68,4 @@ def save_image_files(validated_files, upload_subdir):
 
 
 def delete_saved_images(image_paths):
-    for image_path in image_paths:
-        absolute_path = os.path.join(current_app.static_folder, image_path)
-        if os.path.isfile(absolute_path):
-            try:
-                os.remove(absolute_path)
-            except OSError:
-                pass
+    delete_stored_files(image_paths)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ gunicorn
 psycopg2-binary
 python-dotenv
 Flask-Migrate
+boto3

--- a/scripts/migrate_uploads_to_r2.py
+++ b/scripts/migrate_uploads_to_r2.py
@@ -1,0 +1,241 @@
+"""Upload legacy app/static/uploads files to Cloudflare R2 and rewrite DB URLs.
+
+Default mode is dry-run. Set CONFIRM_R2_MIGRATION=YES to upload and update.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from sqlalchemy import Text, String, select, update
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+load_dotenv(ROOT_DIR / ".env")
+
+from app import create_app  # noqa: E402
+from app.models import db  # noqa: E402
+from app.services.storage import (  # noqa: E402
+    R2_REQUIRED_ENV_VARS,
+    content_type_for_extension,
+    public_base_url,
+    r2_client,
+)
+
+
+UPLOAD_ROOT = ROOT_DIR / "app" / "static" / "uploads"
+CONFIRM_VALUE = "YES"
+ALLOWED_IMAGE_EXTENSIONS = {"jpg", "jpeg", "png", "webp", "gif"}
+SKIPPED_FILE_NAMES = {".gitkeep", ".DS_Store", "Thumbs.db"}
+SKIPPED_DIR_NAMES = {"__pycache__"}
+UPLOAD_REFERENCE_RE = re.compile(
+    r"(app/static/uploads/|/static/uploads/|static/uploads/)([^\s\"'<>)]*)"
+)
+
+
+def log(message):
+    print(message, flush=True)
+
+
+def require_environment():
+    missing = [name for name in ("DATABASE_URL", *R2_REQUIRED_ENV_VARS) if not os.environ.get(name)]
+    if missing:
+        raise RuntimeError("Missing required environment variables: " + ", ".join(missing))
+
+
+def is_dry_run():
+    return os.environ.get("CONFIRM_R2_MIGRATION") != CONFIRM_VALUE
+
+
+def should_skip_path(path):
+    parts = path.relative_to(UPLOAD_ROOT).parts
+    for part in parts[:-1]:
+        if part in SKIPPED_DIR_NAMES or part.startswith("."):
+            return True
+
+    filename = path.name
+    if filename in SKIPPED_FILE_NAMES or filename.startswith("."):
+        return True
+    return path.suffix.lower().lstrip(".") not in ALLOWED_IMAGE_EXTENSIONS
+
+
+def iter_upload_files(upload_root):
+    if not upload_root.exists():
+        return [], 0
+
+    files = []
+    skipped = 0
+    for path in upload_root.rglob("*"):
+        if path.is_dir():
+            continue
+        if should_skip_path(path):
+            skipped += 1
+            continue
+        files.append(path)
+    return files, skipped
+
+
+def relative_upload_path(path):
+    return path.relative_to(UPLOAD_ROOT).as_posix()
+
+
+def r2_key_for_path(path):
+    return f"uploads/{relative_upload_path(path)}"
+
+
+def r2_url_for_relative_path(relative_path):
+    return f"{public_base_url()}/uploads/{relative_path}"
+
+
+def upload_files(files, dry_run):
+    uploaded = {}
+    skipped = 0
+    failed = {}
+    client = None if dry_run else r2_client()
+    bucket = os.environ["R2_BUCKET_NAME"]
+
+    for path in files:
+        relative_path = relative_upload_path(path)
+        key = f"uploads/{relative_path}"
+        url = r2_url_for_relative_path(relative_path)
+        if dry_run:
+            log(f"[dry-run] upload {path} -> r2://{bucket}/{key}")
+            uploaded[relative_path] = url
+            continue
+
+        extension = path.suffix.lower().lstrip(".")
+        try:
+            with path.open("rb") as file_obj:
+                client.upload_fileobj(
+                    file_obj,
+                    bucket,
+                    key,
+                    ExtraArgs={"ContentType": content_type_for_extension(extension)},
+                )
+            uploaded[relative_path] = url
+            log(f"[upload] {path} -> {url}")
+        except Exception as exc:
+            failed[relative_path] = str(exc)
+            skipped += 1
+            log(f"[upload-failed] {path}: {exc}")
+
+    return uploaded, skipped, failed
+
+
+def convert_value(value, uploaded):
+    if not isinstance(value, str):
+        return value, False
+
+    changed = False
+
+    def replace(match):
+        nonlocal changed
+        relative_path = match.group(2).replace("\\", "/").lstrip("/")
+        new_url = uploaded.get(relative_path)
+        if not new_url:
+            return match.group(0)
+        changed = True
+        return new_url
+
+    converted = UPLOAD_REFERENCE_RE.sub(replace, value)
+    return converted, changed
+
+
+def string_columns(table):
+    return [
+        column
+        for column in table.columns
+        if isinstance(column.type, (String, Text))
+    ]
+
+
+def primary_key_filter(table, row):
+    conditions = []
+    for column in table.primary_key.columns:
+        conditions.append(column == row[column.name])
+    return conditions
+
+
+def plan_database_updates(uploaded):
+    plans = []
+    metadata = db.metadata
+    for table in metadata.sorted_tables:
+        columns = string_columns(table)
+        if not columns or not table.primary_key.columns:
+            continue
+
+        rows = db.session.execute(select(table)).mappings()
+        for row in rows:
+            updates = {}
+            for column in columns:
+                converted, changed = convert_value(row[column.name], uploaded)
+                if changed:
+                    updates[column.name] = converted
+            if updates:
+                plans.append((table, dict(row), updates))
+    return plans
+
+
+def apply_database_updates(plans):
+    updated_records = 0
+    with db.engine.begin() as connection:
+        for table, row, updates in plans:
+            statement = update(table).where(*primary_key_filter(table, row)).values(**updates)
+            result = connection.execute(statement)
+            updated_records += result.rowcount or 0
+            log(f"[db-update] {table.name} {updates}")
+    return updated_records
+
+
+def main():
+    require_environment()
+    dry_run = is_dry_run()
+    log("Mode: dry-run" if dry_run else "Mode: execute")
+    log(f"Upload root: {UPLOAD_ROOT}")
+
+    files, skipped_scan_files = iter_upload_files(UPLOAD_ROOT)
+    log(f"Scanned files: {len(files)}")
+    log(f"Planned uploads: {len(files)}")
+
+    uploaded, skipped_files, failed = upload_files(files, dry_run=dry_run)
+    log(f"Uploaded files: {len(uploaded) if not dry_run else 0}")
+    log(f"Skipped files: {skipped_scan_files + skipped_files}")
+    if failed:
+        log(f"Failed uploads: {len(failed)}")
+        if not dry_run:
+            raise RuntimeError("One or more uploads failed; database updates were not attempted.")
+
+    app = create_app()
+    with app.app_context():
+        plans = plan_database_updates(uploaded)
+        log(f"Planned DB record updates: {len(plans)}")
+        sample_url = next(iter(uploaded.values()), "")
+        if sample_url:
+            log(f"Example new URL: {sample_url}")
+        if dry_run:
+            for table, row, updates in plans[:20]:
+                pk = {column.name: row[column.name] for column in table.primary_key.columns}
+                log(f"[dry-run] update {table.name} pk={pk} fields={list(updates)}")
+            log("Dry-run complete. Set CONFIRM_R2_MIGRATION=YES to execute.")
+            return
+
+        try:
+            updated_records = apply_database_updates(plans)
+        except Exception:
+            db.session.rollback()
+            log("Database update failed; transaction rolled back.")
+            raise
+
+        log(f"Updated records: {updated_records}")
+        log(f"Example new URL: {next(iter(uploaded.values()), '')}")
+        log("Migration complete. Local files were not deleted.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 本次完成内容
- 新增 Cloudflare R2 上传服务
- 将用户上传图片从本地 uploads 改为 R2 对象存储
- 新增旧 uploads 图片迁移脚本
- 已将旧头像、圈子、评论、私信图片上传到 R2
- 已将 Neon 中旧头像路径更新为 R2 URL
- 更新 requirements.txt，加入 boto3

## 自测情况
- [x] R2 dry-run 正常
- [x] 正式迁移上传 7 个文件
- [x] Neon 更新 4 条用户头像记录
- [x] .gitkeep 被跳过
- [x] 未提交 gatherly_export.json、gatherly_uploads_backup.zip、app/static/uploads/、.env

## 主要修改文件
- requirements.txt
- app/services/storage.py
- app/utils/upload_utils.py
- 相关上传路由
- scripts/migrate_uploads_to_r2.py
- .gitignore

## 注意事项
- Render 需要新增 R2 环境变量
- R2 Secret 不应提交到 GitHub
- 生产环境图片不再依赖 Render 本地文件系统