### PR TITLE
fix: 修复首页未登录内容权限与移动端私信布局

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -9473,8 +9473,38 @@ textarea.form-input {
     overflow: hidden;
   }
 
+  .message-shell.has-active-chat {
+    height: calc(100dvh - 96px);
+    min-height: 0;
+    max-height: calc(100dvh - 96px);
+    overflow: hidden;
+  }
+
+  .message-shell.has-active-chat .message-sidebar {
+    display: none;
+  }
+
+  .message-shell.has-active-chat .message-detail[data-message-chat] {
+    height: 100%;
+    min-height: 0;
+    max-height: none;
+    grid-template-rows: auto auto minmax(0, 1fr) auto;
+  }
+
+  .message-shell.has-active-chat .message-detail-header {
+    position: relative;
+    z-index: 2;
+    background: #ffffff;
+  }
+
   .message-thread {
     padding: 16px 14px 22px;
+  }
+
+  .message-shell.has-active-chat .message-thread {
+    min-height: 0;
+    overflow-y: auto;
+    padding: 16px 14px 20px;
   }
 
   .message-bubble {
@@ -12767,6 +12797,28 @@ body.circle-modal-open {
   color: #6f6f6f;
   font-size: 13px;
   line-height: 1.55;
+}
+
+.home-auth-prompt {
+  display: grid;
+  gap: 14px;
+  align-content: center;
+  min-height: 94px;
+  padding: 18px;
+  border: 1px dashed #d9ddd8;
+  border-radius: 16px;
+  background: #fbfcfb;
+  color: #5f6f67;
+}
+
+.home-auth-prompt p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.home-feed-auth-prompt {
+  max-width: 520px;
 }
 
 .my-events-page {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -120,9 +120,6 @@
             <span aria-hidden="true">&#128276;</span>
             <strong data-notification-badge{% if not unread_notification_count %} hidden style="display: none;"{% endif %}>{{ unread_notification_count if unread_notification_count < 100 else '99+' }}</strong>
           </a>
-          <a class="mobile-nav-button" href="{{ url_for('profile.my_circle_interactions') }}" aria-label="收藏">
-            <span aria-hidden="true">&#9825;</span>
-          </a>
           <button class="mobile-avatar-button" type="button" data-nav-menu-toggle aria-expanded="false" aria-controls="mobile-account-menu">
             <span class="nav-avatar">
               {% if current_user and current_user.avatar %}
@@ -133,10 +130,6 @@
             </span>
             <span class="sr-only">打开用户菜单</span>
           </button>
-        {% else %}
-          <a class="mobile-nav-button" href="{{ url_for('auth.login') }}" aria-label="登录后查看收藏">
-            <span aria-hidden="true">&#9825;</span>
-          </a>
         {% endif %}
         <button class="mobile-nav-button" type="button" data-mobile-menu-toggle aria-expanded="false" aria-controls="mobile-menu">
           <span aria-hidden="true">&#9776;</span>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -310,9 +310,12 @@
 
             <section class="home-sidebar-panel home-mini-groups" aria-labelledby="home-mini-groups-title">
                 <div class="home-sidebar-tabs" id="home-mini-groups-title">
-                    <span>你的同好圈 {{ home_circles|default([])|length }}</span>
+                    <span>你的同好圈{% if session.get('user_id') %} {{ home_circles|default([])|length }}{% endif %}</span>
+                    {% if session.get('user_id') %}
                     <a href="{{ url_for('circle.circles') }}">查看全部</a>
+                    {% endif %}
                 </div>
+                {% if session.get('user_id') %}
                 {% for circle in home_circles|default([]) %}
                     {% if loop.index <= 2 %}
                     <a class="home-mini-group" href="{{ circle.url }}">
@@ -327,6 +330,11 @@
                 <p class="home-sidebar-empty">暂无同好圈</p>
                 {% endfor %}
                 <a class="home-find-groups" href="{{ url_for('circle.circles') }}">发现更多同好圈</a>
+                {% else %}
+                <div class="home-auth-prompt home-sidebar-auth-prompt">
+                    <p>登录后可以查看你的同好圈。</p>
+                </div>
+                {% endif %}
             </section>
         </aside>
 
@@ -394,6 +402,7 @@
             <section class="home-feed-section groups-feed-section" id="from-your-groups">
                 <div class="home-feed-heading">
                     <h2>From your circles</h2>
+                    {% if session.get('user_id') %}
                     <div class="home-feed-actions">
                         <a class="section-link" href="{{ url_for('activity.search', scope='activities') }}">浏览全部活动 <span aria-hidden="true">&#8594;</span></a>
                         <div class="home-date-filter" data-home-date-filter>
@@ -432,8 +441,10 @@
                             </div>
                         </div>
                     </div>
+                    {% endif %}
                 </div>
                 <div class="home-group-feed">
+                    {% if session.get('user_id') %}
                     {% set last_date = namespace(value='') %}
                     {% for activity in group_activities|default([]) %}
                         {% if activity.home_date_label != last_date.value %}
@@ -486,6 +497,11 @@
                     {% else %}
                     <div class="recommended-empty-state">你的同好圈暂时没有近期活动。</div>
                     {% endfor %}
+                    {% else %}
+                    <div class="home-auth-prompt home-feed-auth-prompt">
+                        <p>登录后可以查看来自你同好圈的活动。</p>
+                    </div>
+                    {% endif %}
                 </div>
             </section>
         </main>

--- a/app/templates/messages.html
+++ b/app/templates/messages.html
@@ -5,7 +5,7 @@
 {% block content %}
 <section class="section message-page">
   <div class="container">
-    <div class="message-shell">
+    <div class="message-shell {% if active_user %}has-active-chat{% endif %}">
       <aside class="message-sidebar" aria-label="私信列表">
         <div class="message-sidebar-heading">
           <div>


### PR DESCRIPTION
## 本次修复内容

- 修复未登录用户在首页仍可看到「你的同好圈」内容的问题
- 修复未登录用户仍可查看 From your circles 内容的问题
- 移动端隐藏头像旁边的爱心入口
- 修复移动端私信详情页用户信息与聊天内容重叠的问题

## 自测情况

- [x] 未登录首页只显示 For you 推荐内容
- [x] 未登录时「你的同好圈」显示登录提示
- [x] 未登录时 From your circles 显示登录提示
- [x] 已登录首页原有同好圈内容正常显示
- [x] 移动端导航栏不再显示头像旁边的爱心入口
- [x] 移动端私信详情页不再出现头像/用户名与消息叠加
- [x] python -m compileall app 通过

## 影响范围

- 首页登录态展示
- 移动端导航栏
- 移动端私信详情页布局

## 数据库 / 依赖变更

无数据库变更。
无新增依赖。