### PR TITLE
fix(home-circle): 修复首页圈子展示与验证码提示

### DIFF
--- a/app/routes/activity.py
+++ b/app/routes/activity.py
@@ -130,6 +130,20 @@ def _available_activity_circles():
     )
 
 
+def _circle_cover_url(circle):
+    if not circle:
+        return ""
+    cover_image = getattr(circle, "cover_image", None)
+    if (
+        cover_image
+        and str(cover_image).startswith(
+            ("http://", "https://", "/static/", "static/", "app/static/", "images/circles/", "images/circle_covers/")
+        )
+    ):
+        return storage_url(cover_image)
+    return storage_url("images/circle_covers/default.webp")
+
+
 def _validated_circle_id(raw_circle_id):
     if not raw_circle_id:
         return None
@@ -524,6 +538,7 @@ def _activity_to_summary(
         "tags": tags or [category],
         "circle_id": activity.circle_id,
         "circle_name": activity.circle.name if activity.circle else "",
+        "circle_cover_url": _circle_cover_url(activity.circle),
         "image_url": activity.image,
         "organizer": (
             "Gatherly官方"
@@ -1051,26 +1066,17 @@ def _index_impl():
         .group_by(Activity.circle_id)
         .all()
     )
+    has_joined_circles = bool(joined_circle_ids)
     circle_query = Circle.query.filter_by(status="active")
     if joined_circle_ids:
-        joined_circles = circle_query.filter(Circle.id.in_(joined_circle_ids)).all()
+        joined_circles = (
+            circle_query.filter(Circle.id.in_(joined_circle_ids))
+            .order_by(Circle.is_pinned.desc(), Circle.updated_at.desc(), Circle.id.desc())
+            .limit(4)
+            .all()
+        )
     else:
         joined_circles = []
-    recommended_circles = (
-        Circle.query.filter_by(status="active")
-        .order_by(Circle.is_pinned.desc(), Circle.member_count.desc(), Circle.updated_at.desc())
-        .limit(6)
-        .all()
-    )
-    circle_rows = []
-    seen_circle_ids = set()
-    for circle in joined_circles + recommended_circles:
-        if circle.id in seen_circle_ids:
-            continue
-        seen_circle_ids.add(circle.id)
-        circle_rows.append(circle)
-        if len(circle_rows) >= 4:
-            break
     home_circles = [
         {
             "id": circle.id,
@@ -1090,7 +1096,7 @@ def _index_impl():
             "is_joined": circle.id in joined_circle_ids,
             "url": url_for("circle.circle_detail", circle_id=circle.id),
         }
-        for circle in circle_rows
+        for circle in joined_circles
     ]
 
     group_db_activities = []
@@ -1104,18 +1110,6 @@ def _index_impl():
             .limit(8)
             .all()
         )
-    if not group_db_activities:
-        recommended_circle_ids = [circle.id for circle in recommended_circles[:4]]
-        if recommended_circle_ids:
-            group_db_activities = (
-                Activity.query.filter(
-                    Activity.status == "open",
-                    Activity.circle_id.in_(recommended_circle_ids),
-                )
-                .order_by(Activity.is_featured.desc(), Activity.start_time.asc(), Activity.id.desc())
-                .limit(8)
-                .all()
-            )
     normalized_by_id = {activity["id"]: activity for activity in featured_normalized_activities}
     group_activities = [
         normalized_by_id[activity.id]
@@ -1123,8 +1117,6 @@ def _index_impl():
         if activity.id in normalized_by_id
         and normalized_by_id[activity.id]["phase"] in {"upcoming", "ongoing"}
     ]
-    if not group_activities:
-        group_activities = featured_activities[:6] or filtered_activities[:6]
     sidebar_going_activity = None
     sidebar_saved_activity = None
     if current_user:
@@ -1181,6 +1173,7 @@ def _index_impl():
         featured_activities=featured_activities,
         group_activities=group_activities,
         home_circles=home_circles,
+        has_joined_circles=has_joined_circles,
         home_user_card=home_user_card,
         home_calendar=_home_calendar_payload(),
         sidebar_going_activity=sidebar_going_activity,

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -35,6 +35,7 @@ REGISTER_FORM_DRAFT_FIELDS = ("username", "email", "nickname", "city")
 EMAIL_CODE_SESSION_LIMIT_SECONDS = 60 * 60
 EMAIL_CODE_SESSION_LIMIT_MAX = 10
 EMAIL_CODE_RATE_LIMIT_MESSAGE = "验证码发送过于频繁，请稍后再试。"
+EMAIL_CODE_SPAM_FOLDER_MESSAGE = "若在邮箱没有看到验证码，请检查邮箱垃圾箱"
 DELETE_ACCOUNT_CONFIRM_TEXT = "DELETE MY ACCOUNT"
 LOGIN_FAILURE_WINDOW_SECONDS = 5 * 60
 LOGIN_FAILURE_MAX_ATTEMPTS = 5
@@ -197,10 +198,12 @@ def _flash_email_code_send_result(sent, success_message="验证码已发送，�
             flash("本地未配置邮件服务，验证码已打印到控制台。", "info")
         else:
             flash(success_message, "success")
+        flash(EMAIL_CODE_SPAM_FOLDER_MESSAGE, "info")
     elif configuration_error := email_configuration_error():
         flash(configuration_error, "error")
     elif is_console_email_provider():
         flash("本地未配置邮件服务，验证码已打印到控制台。", "info")
+        flash(EMAIL_CODE_SPAM_FOLDER_MESSAGE, "info")
     else:
         flash("验证码发送失败，请稍后再试。", "error")
 
@@ -320,6 +323,7 @@ def send_reset_password_code():
             )
         else:
             flash("如果该邮箱已注册，验证码将发送到对应邮箱。", "success")
+            flash(EMAIL_CODE_SPAM_FOLDER_MESSAGE, "info")
     return redirect(url_for("auth.forgot_password"))
 
 

--- a/app/routes/circle.py
+++ b/app/routes/circle.py
@@ -810,27 +810,49 @@ def _build_comment_threads(comments, current_user, circle, include_hidden=False)
 @circle_bp.route("/circles")
 def circles():
     _sync_system_circles()
-    circle_rows = Circle.query.filter(Circle.status.in_(["active", "private"])).all()
+    selected_circle_category = request.args.get("category", "").strip()
+    circle_query = Circle.query.filter(Circle.status.in_(["active", "private"]))
+    if selected_circle_category == "官方":
+        circle_query = circle_query.filter(Circle.is_system.is_(True))
+    if selected_circle_category == "新同好圈":
+        circle_query = circle_query.order_by(Circle.created_at.desc(), Circle.id.desc())
+    circle_rows = circle_query.all()
     decorated = [_decorate_circle(circle) for circle in circle_rows]
+    if selected_circle_category == "热门":
+        decorated = [circle for circle in decorated if circle.is_hot]
     circle_ids = [circle.id for circle in decorated]
     activities_by_circle, activity_counts_by_circle = _build_circle_activity_summaries(circle_ids)
     for circle in decorated:
         circle.recent_activities = activities_by_circle.get(circle.id, [])
         circle.recent_activity_count = activity_counts_by_circle.get(circle.id, 0)
-    decorated.sort(
-        key=lambda circle: (
-            circle.is_pinned,
-            circle.pinned_at or datetime.min,
-            circle.recent_activity_count,
-            circle.heat_score,
-            circle.member_count,
-            circle.post_count,
-            circle.updated_at or circle.created_at,
-            circle.created_at,
-        ),
-        reverse=True,
+    if selected_circle_category == "新同好圈":
+        decorated.sort(
+            key=lambda circle: (
+                circle.created_at or datetime.min,
+                circle.id,
+            ),
+            reverse=True,
+        )
+    else:
+        decorated.sort(
+            key=lambda circle: (
+                circle.is_pinned,
+                circle.pinned_at or datetime.min,
+                circle.recent_activity_count,
+                circle.heat_score,
+                circle.member_count,
+                circle.post_count,
+                circle.updated_at or circle.created_at,
+                circle.created_at,
+            ),
+            reverse=True,
+        )
+    return render_template(
+        "circle.html",
+        circles=decorated,
+        selected_circle_category=selected_circle_category,
+        **_upload_limit_context(),
     )
-    return render_template("circle.html", circles=decorated, **_upload_limit_context())
 
 
 @circle_bp.route("/circle")
@@ -1485,7 +1507,7 @@ def create_post(circle_id):
         flash("同好圈不存在或暂不可见。", "error")
         return redirect(url_for("circle.circles"))
 
-    if not _is_member(circle.id, user.id):
+    if not _is_member(circle.id, user.id) and not _can_manage_circle(user, circle):
         flash("加入同好圈后才能发帖。", "error")
         return redirect(url_for("circle.circle_detail", circle_id=circle.id))
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -8752,6 +8752,15 @@ textarea.form-input {
   font-weight: 800;
 }
 
+.meetup-detail-circle-thumb {
+  width: 52px;
+  height: 52px;
+  flex: 0 0 auto;
+  border-radius: 12px;
+  object-fit: cover;
+  background: #f3f0ea;
+}
+
 .meetup-detail-circle-card div {
   display: grid;
 }

--- a/app/templates/activity_detail.html
+++ b/app/templates/activity_detail.html
@@ -85,7 +85,10 @@
 
                     {% if activity.circle_id and circle_name %}
                     <div class="meetup-detail-circle-card">
-                        <span class="meetup-detail-circle-mark" aria-hidden="true">G</span>
+                        <img class="meetup-detail-circle-thumb"
+                             src="{{ activity.circle_cover_url or url_for('static', filename='images/circle_covers/default.webp') }}"
+                             alt="{{ circle_name }} 缩略图"
+                             onerror="this.src='{{ url_for('static', filename='images/circle_covers/default.webp') }}'">
                         <div>
                             <span>所属同好圈</span>
                             <strong><a href="{{ url_for('circle.circle_detail', circle_id=activity.circle_id) }}">{{ circle_name }}</a></strong>

--- a/app/templates/circle.html
+++ b/app/templates/circle.html
@@ -75,9 +75,8 @@
             <button class="meetup-banner-close" type="button" aria-label="关闭提示" data-banner-dismiss>&times;</button>
         </section>
 
-        {% if circles %}
+        {% if circles or selected_circle_category %}
         {% set circle_categories = [
-            {'icon':'👥','tag':'新同好圈','aliases':'新同好圈'},
             {'icon':'🎉','tag':'社交活动','aliases':'社交活动,咖啡茶饮,美食烘焙'},
             {'icon':'🎨','tag':'兴趣爱好','aliases':'兴趣爱好,影像摄影,摄影影像,手作艺术,咖啡茶饮,美食烘焙'},
             {'icon':'⚽','tag':'运动健身','aliases':'运动健身,运动户外'},
@@ -125,12 +124,24 @@
         <nav class="meetup-category-shell" aria-label="同好圈分类导航">
             <button class="category-scroll-arrow is-left" type="button" aria-label="向左滚动分类" onclick="this.parentElement.querySelector('.meetup-category-rail').scrollBy({left:-280,behavior:'smooth'})">&#8592;</button>
             <div class="meetup-category-rail icon-category-nav">
-                <a class="icon-category is-active" href="#" data-category="all" data-filter-tags="">
+                <a class="icon-category {% if not selected_circle_category %}is-active{% endif %}" href="{{ url_for('circle.circles') }}" data-category="all" data-filter-tags="">
                     <span class="icon-category-symbol" aria-hidden="true">✨</span>
                     <span class="icon-category-label">全部同好圈</span>
                 </a>
+                <a class="icon-category {% if selected_circle_category == '热门' %}is-active{% endif %}" href="{{ url_for('circle.circles', category='热门') }}" data-category="热门" data-filter-tags="热门">
+                    <span class="icon-category-symbol" aria-hidden="true">🔥</span>
+                    <span class="icon-category-label">热门</span>
+                </a>
+                <a class="icon-category {% if selected_circle_category == '官方' %}is-active{% endif %}" href="{{ url_for('circle.circles', category='官方') }}" data-category="官方" data-filter-tags="官方">
+                    <span class="icon-category-symbol" aria-hidden="true">✓</span>
+                    <span class="icon-category-label">官方</span>
+                </a>
+                <a class="icon-category {% if selected_circle_category == '新同好圈' %}is-active{% endif %}" href="{{ url_for('circle.circles', category='新同好圈') }}" data-category="新同好圈" data-filter-tags="">
+                    <span class="icon-category-symbol" aria-hidden="true">👥</span>
+                    <span class="icon-category-label">新同好圈</span>
+                </a>
                 {% for category in circle_categories %}
-                <a class="icon-category" href="#" data-category="{{ category.tag }}" data-filter-tags="{{ category.aliases }}">
+                <a class="icon-category {% if selected_circle_category == category.tag %}is-active{% endif %}" href="#" data-category="{{ category.tag }}" data-filter-tags="{{ category.aliases }}">
                     <span class="icon-category-symbol" aria-hidden="true">{{ category.icon }}</span>
                     <span class="icon-category-label">{{ category.tag }}</span>
                 </a>
@@ -143,7 +154,7 @@
         </div>
         <div class="card-grid circle-grid circle-discovery-grid">
             {% for circle in circles %}
-            <article class="activity-card circle-card circle-discovery-card discover-card" data-tags="{{ circle.tag or '兴趣爱好' }},{{ circle.name }}" data-time="any">
+            <article class="activity-card circle-card circle-discovery-card discover-card" data-tags="{{ circle.tag or '兴趣爱好' }},{{ circle.name }}{% if circle.is_hot %},热门{% endif %}{% if circle.is_system %},官方{% endif %}" data-time="any">
                 <a class="circle-card-cover" href="{{ url_for('circle.circle_detail', circle_id=circle.id) }}">
                     <img src="{{ circle.cover_image_url|asset_url }}" alt="{{ circle.name }} cover">
                     <span class="circle-card-cover-overlay"></span>

--- a/app/templates/circle_detail.html
+++ b/app/templates/circle_detail.html
@@ -335,8 +335,10 @@
                             <p class="eyebrow">Photos</p>
                             <h2 id="circle-photos-title">照片 <span>{{ photo_items|length }}</span></h2>
                         </div>
-                        {% if current_user and is_member %}
+                        {% if current_user and (is_member or can_manage_circle) %}
                         <a class="circle-add-photo-button" href="{{ url_for('circle.create_post', circle_id=circle.id) }}">上传照片</a>
+                        {% elif current_user %}
+                        <span class="circle-add-photo-button is-disabled" aria-disabled="true">加入同好圈后可以上传照片</span>
                         {% else %}
                         <a class="circle-add-photo-button" href="{{ url_for('auth.login', next=request.url) }}">登录后上传照片</a>
                         {% endif %}
@@ -558,7 +560,7 @@
                 </section>
 
                 {% if can_manage_circle %}
-                <details class="circle-management-panel" open>
+                <details class="circle-management-panel">
                     <summary>管理圈子</summary>
                     {% if is_circle_owner or current_user.role == 'admin' %}
                     <section class="management-card circle-privacy-panel">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -274,13 +274,13 @@
                      role="tabpanel"
                      data-home-mini-panel="upcoming">
                     {% if sidebar_going_activity %}
-                    <article class="home-mini-event" aria-label="{{ sidebar_going_activity.title }}">
+                    <a class="home-mini-event" href="{{ sidebar_going_activity.detail_url }}" aria-label="{{ sidebar_going_activity.title }}">
                         <img src="{{ sidebar_going_activity.image_url or url_for('static', filename='images/placeholder-activity.jpg') }}" alt="{{ sidebar_going_activity.title }}" onerror="this.src='{{ url_for('static', filename='images/placeholder-activity.jpg') }}'">
                         <span>
                             <strong>{{ sidebar_going_activity.title }}</strong>
                             <small>{{ sidebar_going_activity.sidebar_time or sidebar_going_activity.time }}</small>
                         </span>
-                    </article>
+                    </a>
                     {% elif session.get('user_id') %}
                     <p class="home-sidebar-empty">暂无即将开始的报名活动，去浏览更多活动吧。</p>
                     {% else %}
@@ -293,13 +293,13 @@
                      data-home-mini-panel="saved"
                      hidden>
                     {% if sidebar_saved_activity %}
-                    <article class="home-mini-event" aria-label="{{ sidebar_saved_activity.title }}">
+                    <a class="home-mini-event" href="{{ sidebar_saved_activity.detail_url }}" aria-label="{{ sidebar_saved_activity.title }}">
                         <img src="{{ sidebar_saved_activity.image_url or url_for('static', filename='images/placeholder-activity.jpg') }}" alt="{{ sidebar_saved_activity.title }}" onerror="this.src='{{ url_for('static', filename='images/placeholder-activity.jpg') }}'">
                         <span>
                             <strong>{{ sidebar_saved_activity.title }}</strong>
                             <small>{{ sidebar_saved_activity.sidebar_time or sidebar_saved_activity.time }}</small>
                         </span>
-                    </article>
+                    </a>
                     {% elif session.get('user_id') %}
                     <p class="home-sidebar-empty">暂无收藏活动，可以先收藏感兴趣的活动。</p>
                     {% else %}
@@ -312,7 +312,7 @@
                 <div class="home-sidebar-tabs" id="home-mini-groups-title">
                     <span>你的同好圈{% if session.get('user_id') %} {{ home_circles|default([])|length }}{% endif %}</span>
                     {% if session.get('user_id') %}
-                    <a href="{{ url_for('circle.circles') }}">查看全部</a>
+                    <a href="{{ url_for('circle.my_groups') }}">查看全部</a>
                     {% endif %}
                 </div>
                 {% if session.get('user_id') %}
@@ -327,7 +327,7 @@
                     </a>
                     {% endif %}
                 {% else %}
-                <p class="home-sidebar-empty">暂无同好圈</p>
+                <p class="home-sidebar-empty">你还没有加入任何同好圈，加入圈子后这里会显示圈内活动和动态。</p>
                 {% endfor %}
                 <a class="home-find-groups" href="{{ url_for('circle.circles') }}">发现更多同好圈</a>
                 {% else %}
@@ -445,6 +445,7 @@
                 </div>
                 <div class="home-group-feed">
                     {% if session.get('user_id') %}
+                    {% if has_joined_circles %}
                     {% set last_date = namespace(value='') %}
                     {% for activity in group_activities|default([]) %}
                         {% if activity.home_date_label != last_date.value %}
@@ -497,6 +498,9 @@
                     {% else %}
                     <div class="recommended-empty-state">你的同好圈暂时没有近期活动。</div>
                     {% endfor %}
+                    {% else %}
+                    <div class="recommended-empty-state">你还没有加入任何同好圈，加入圈子后这里会显示圈内活动和动态。</div>
+                    {% endif %}
                     {% else %}
                     <div class="home-auth-prompt home-feed-auth-prompt">
                         <p>登录后可以查看来自你同好圈的活动。</p>


### PR DESCRIPTION
## 本次完成内容
- 修复首页左侧活动无法点击进入活动详情页的问题
- 发送邮箱验证码成功后增加垃圾箱检查提示
- 优化首页 From your circles 和“你的同好圈”的空状态显示
- 活动详情页所属同好圈增加缩略图展示
- 修复已登录用户在圈子详情页仍看到登录后才能上传照片的提示
- 管理员/圈主的管理圈子板块默认折叠
- 修复全部同好圈中“新同好圈”筛选逻辑

## 自测情况
- [ ] 首页左侧活动可点击进入详情页
- [ ] 发送邮箱验证码成功后提示正常显示，表单不被清空
- [ ] 未加入圈子的用户看到空状态提示
- [ ] 加入圈子后首页相关圈子内容正常显示
- [ ] 活动详情页所属同好圈缩略图正常显示
- [ ] 登录后圈子详情页上传照片提示正常
- [ ] 管理圈子板块默认折叠且可展开
- [ ] 新同好圈筛选能显示最近创建的圈子
- [ ] python -m compileall app 通过
- [ ] git diff --check 通过

## 数据库说明
本次未新增数据库字段，未新增 migration。