### PR TITLE
enhance(ENH-08): 为首页和同好圈增加轻量 GSAP 动效

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -10,6 +10,55 @@ document.addEventListener("DOMContentLoaded", () => {
 
   initCurrentYear();
 
+  const initGsapMotion = () => {
+    const gsap = window.gsap;
+    if (!gsap) {
+      console.info("[Gatherly] GSAP not loaded, skip motion");
+      return;
+    }
+
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches) {
+      console.info("[Gatherly] reduced motion enabled, skip GSAP motion");
+      return;
+    }
+
+    const cards = gsap.utils.toArray(".js-gsap-card");
+    const chips = gsap.utils.toArray(".js-gsap-chip");
+    console.info("[Gatherly] GSAP motion initialized", { cards: cards.length, chips: chips.length });
+
+    if (cards.length) {
+      gsap.fromTo(cards, {
+        autoAlpha: 0,
+        y: 36,
+        scale: 0.96,
+      }, {
+        autoAlpha: 1,
+        y: 0,
+        scale: 1,
+        duration: 0.6,
+        ease: "power3.out",
+        stagger: 0.09,
+        clearProps: "transform,opacity,visibility,willChange",
+      });
+    }
+
+    if (chips.length) {
+      gsap.fromTo(chips, {
+        autoAlpha: 0,
+        y: 14,
+      }, {
+        autoAlpha: 1,
+        y: 0,
+        duration: 0.38,
+        ease: "power2.out",
+        stagger: 0.045,
+        clearProps: "transform,opacity,visibility,willChange",
+      });
+    }
+  };
+
+  initGsapMotion();
+
   const flashMessages = document.querySelectorAll(".flash-msg, .flash-message");
   flashMessages.forEach(message => {
     window.setTimeout(() => {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -258,6 +258,7 @@
       }, { once: true });
     </script>
   {% endif %}
-  <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+  <script src="{{ url_for('static', filename='js/main.js', v='enh-08-gsap') }}"></script>
 </body>
 </html>

--- a/app/templates/circle.html
+++ b/app/templates/circle.html
@@ -124,24 +124,24 @@
         <nav class="meetup-category-shell" aria-label="同好圈分类导航">
             <button class="category-scroll-arrow is-left" type="button" aria-label="向左滚动分类" onclick="this.parentElement.querySelector('.meetup-category-rail').scrollBy({left:-280,behavior:'smooth'})">&#8592;</button>
             <div class="meetup-category-rail icon-category-nav">
-                <a class="icon-category {% if not selected_circle_category %}is-active{% endif %}" href="{{ url_for('circle.circles') }}" data-category="all" data-filter-tags="">
+                <a class="icon-category js-gsap-chip {% if not selected_circle_category %}is-active{% endif %}" href="{{ url_for('circle.circles') }}" data-category="all" data-filter-tags="">
                     <span class="icon-category-symbol" aria-hidden="true">✨</span>
                     <span class="icon-category-label">全部同好圈</span>
                 </a>
-                <a class="icon-category {% if selected_circle_category == '热门' %}is-active{% endif %}" href="{{ url_for('circle.circles', category='热门') }}" data-category="热门" data-filter-tags="热门">
+                <a class="icon-category js-gsap-chip {% if selected_circle_category == '热门' %}is-active{% endif %}" href="{{ url_for('circle.circles', category='热门') }}" data-category="热门" data-filter-tags="热门">
                     <span class="icon-category-symbol" aria-hidden="true">🔥</span>
                     <span class="icon-category-label">热门</span>
                 </a>
-                <a class="icon-category {% if selected_circle_category == '官方' %}is-active{% endif %}" href="{{ url_for('circle.circles', category='官方') }}" data-category="官方" data-filter-tags="官方">
+                <a class="icon-category js-gsap-chip {% if selected_circle_category == '官方' %}is-active{% endif %}" href="{{ url_for('circle.circles', category='官方') }}" data-category="官方" data-filter-tags="官方">
                     <span class="icon-category-symbol" aria-hidden="true">✓</span>
                     <span class="icon-category-label">官方</span>
                 </a>
-                <a class="icon-category {% if selected_circle_category == '新同好圈' %}is-active{% endif %}" href="{{ url_for('circle.circles', category='新同好圈') }}" data-category="新同好圈" data-filter-tags="">
+                <a class="icon-category js-gsap-chip {% if selected_circle_category == '新同好圈' %}is-active{% endif %}" href="{{ url_for('circle.circles', category='新同好圈') }}" data-category="新同好圈" data-filter-tags="">
                     <span class="icon-category-symbol" aria-hidden="true">👥</span>
                     <span class="icon-category-label">新同好圈</span>
                 </a>
                 {% for category in circle_categories %}
-                <a class="icon-category {% if selected_circle_category == category.tag %}is-active{% endif %}" href="#" data-category="{{ category.tag }}" data-filter-tags="{{ category.aliases }}">
+                <a class="icon-category js-gsap-chip {% if selected_circle_category == category.tag %}is-active{% endif %}" href="#" data-category="{{ category.tag }}" data-filter-tags="{{ category.aliases }}">
                     <span class="icon-category-symbol" aria-hidden="true">{{ category.icon }}</span>
                     <span class="icon-category-label">{{ category.tag }}</span>
                 </a>
@@ -154,7 +154,7 @@
         </div>
         <div class="card-grid circle-grid circle-discovery-grid">
             {% for circle in circles %}
-            <article class="activity-card circle-card circle-discovery-card discover-card" data-tags="{{ circle.tag or '兴趣爱好' }},{{ circle.name }}{% if circle.is_hot %},热门{% endif %}{% if circle.is_system %},官方{% endif %}" data-time="any">
+            <article class="activity-card circle-card circle-discovery-card discover-card js-gsap-card" data-tags="{{ circle.tag or '兴趣爱好' }},{{ circle.name }}{% if circle.is_hot %},热门{% endif %}{% if circle.is_system %},官方{% endif %}" data-time="any">
                 <a class="circle-card-cover" href="{{ url_for('circle.circle_detail', circle_id=circle.id) }}">
                     <img src="{{ circle.cover_image_url|asset_url }}" alt="{{ circle.name }} cover">
                     <span class="circle-card-cover-overlay"></span>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 {% macro activity_card(activity, detail_url, favorite_activity_id, demo=false) %}
-<article class="activity-card discover-card" tabindex="0" role="link" data-card-url="{{ detail_url }}" data-tags="{{ activity.tags|join(',') if activity.tags else activity.category }}" data-time="{{ activity.time_filter|default('any') }}" data-activity-type="{{ 'online' if activity.location and ('线上' in activity.location or 'Online' in activity.location or 'online' in activity.location) else 'offline' }}">
+<article class="activity-card discover-card js-gsap-card" tabindex="0" role="link" data-card-url="{{ detail_url }}" data-tags="{{ activity.tags|join(',') if activity.tags else activity.category }}" data-time="{{ activity.time_filter|default('any') }}" data-activity-type="{{ 'online' if activity.location and ('线上' in activity.location or 'Online' in activity.location or 'online' in activity.location) else 'offline' }}">
     <div class="card-image {% if not activity.image_url %}is-placeholder-image{% endif %}">
         <img src="{{ activity.image_url or url_for('static', filename='images/placeholders/activity-placeholder.svg') }}"
              alt="{{ activity.title }}"
@@ -351,7 +351,7 @@
                     <button class="home-scroll-button is-previous" type="button" aria-label="查看上一组推荐活动" data-recommended-previous>&#8592;</button>
                     <div class="home-for-you-track" data-recommended-track>
                     {% for activity in featured_activities %}
-                        <article class="home-event-card" tabindex="0" role="link" data-card-url="{{ activity.detail_url }}" data-tags="{{ activity.tags|join(',') if activity.tags else activity.category }}" data-time="{{ activity.time_filter|default('any') }}">
+                        <article class="home-event-card js-gsap-card" tabindex="0" role="link" data-card-url="{{ activity.detail_url }}" data-tags="{{ activity.tags|join(',') if activity.tags else activity.category }}" data-time="{{ activity.time_filter|default('any') }}">
                             <div class="home-event-image {% if not activity.image_url %}is-placeholder-image{% endif %}">
                                 <img src="{{ activity.image_url or url_for('static', filename='images/placeholders/activity-placeholder.svg') }}" alt="{{ activity.title }}" onerror="this.src='{{ url_for('static', filename='images/placeholders/activity-placeholder.svg') }}'">
                                 <div class="home-card-actions">
@@ -455,7 +455,7 @@
                         <p class="home-feed-date">{{ activity.home_date_label }}</p>
                         {% set last_date.value = activity.home_date_label %}
                         {% endif %}
-                        <article class="home-group-event" tabindex="0" role="link" data-card-url="{{ activity.detail_url }}" data-tags="{{ activity.tags|join(',') if activity.tags else activity.category }}" data-time="{{ activity.time_filter|default('any') }}">
+                        <article class="home-group-event js-gsap-card" tabindex="0" role="link" data-card-url="{{ activity.detail_url }}" data-tags="{{ activity.tags|join(',') if activity.tags else activity.category }}" data-time="{{ activity.time_filter|default('any') }}">
                             <div class="home-group-image">
                                 <img src="{{ activity.image_url or url_for('static', filename='images/placeholders/activity-placeholder.svg') }}" alt="{{ activity.title }}" onerror="this.src='{{ url_for('static', filename='images/placeholders/activity-placeholder.svg') }}'">
                                 <div class="home-card-actions">
@@ -626,7 +626,7 @@
                 <p class="interest-subtitle">点击分类即可筛选活动。</p>
             </div>
             <div class="interest-tags icon-category-nav" role="navigation" aria-label="活动分类">
-                <a class="interest-chip icon-category {% if not selected_category %}is-active{% endif %}"
+                <a class="interest-chip icon-category js-gsap-chip {% if not selected_category %}is-active{% endif %}"
                    href="{{ url_for('activity.index', time=selected_time) if selected_time != 'any' else url_for('activity.index') }}#discover-events"
                    data-category="all" data-filter-tags="">
                     <span class="icon-category-symbol" aria-hidden="true">✨</span>
@@ -635,7 +635,7 @@
                 {% for category in interest_categories %}
                 {% set is_special_activity_filter = category.tag in special_activity_filter_tags|default([]) %}
                 {% set category_filter_tags = '' if is_special_activity_filter else category.tag %}
-                <a class="interest-chip icon-category {% if selected_category == category.tag %}is-active{% endif %}"
+                <a class="interest-chip icon-category js-gsap-chip {% if selected_category == category.tag %}is-active{% endif %}"
                    href="{{ url_for('activity.index', category=category.tag, time=selected_time) if selected_time != 'any' else url_for('activity.index', category=category.tag) }}#discover-events"
                    data-category="{{ category.tag }}" data-filter-tags="{{ category_filter_tags }}">
                     <span class="icon-category-symbol" aria-hidden="true">{{ category.icon }}</span>
@@ -676,7 +676,7 @@
                 {"icon": "&#127939;", "name": "周末轻运动", "tag": "运动户外", "members": "419", "description": "新手友好的跑步和户外活动。"}
             ] %}
             {% for circle in home_circles %}
-            <article class="popular-circle-card">
+            <article class="popular-circle-card js-gsap-card">
                 <span class="circle-card-icon" aria-hidden="true">{{ circle.icon|safe }}</span>
                 <span class="tag">{{ circle.tag }}</span>
                 <h3>{{ circle.name }}</h3>


### PR DESCRIPTION
## 关联 Issue
Closes #ENH-08对应的GitHub编号

## 本次完成内容
- 在 base.html 中通过 CDN 引入 GSAP
- 为首页活动卡片增加轻量淡入上浮动效
- 为兴趣标签 chip 增加 stagger 动效
- 为同好圈卡片增加轻量淡入上浮动效
- 保留 prefers-reduced-motion 兼容逻辑
- 保证 GSAP 加载失败时页面内容仍正常显示

## 自测情况
- [x] `git diff --check` 通过
- [x] `python -m compileall app` 通过
- [x] 首页活动卡片动效正常
- [x] 兴趣标签 chip 动效正常
- [x] 同好圈卡片动效正常
- [x] 浏览器 Console 无红色 JS 报错
- [x] 移动端窄屏无明显错位

## 主要修改文件
- app/templates/base.html
- app/templates/index.html
- app/templates/circle.html
- app/static/js/main.js

## 需要 Review 的重点
请检查 GSAP CDN 加载顺序、动画是否过度、是否影响页面默认显示，以及是否符合 Gatherly 统一视觉风格。