### PR TITLE
style(ENH-09): 移除后台首页账号设置卡片

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -35,6 +35,54 @@ CIRCLE_STATUSES = {"active", "hidden"}
 CONTENT_STATUSES = {"published", "hidden"}
 FEEDBACK_STATUSES = ("open", "replied", "closed")
 SORT_OPTIONS = {"newest", "oldest"}
+ADMIN_LIST_PER_PAGE = 20
+
+
+class ListPagination:
+    def __init__(self, items, page, per_page, total):
+        self.items = items
+        self.page = page
+        self.per_page = per_page
+        self.total = total
+        self.pages = (total + per_page - 1) // per_page if total else 0
+        self.has_prev = page > 1
+        self.has_next = page < self.pages
+        self.prev_num = page - 1 if self.has_prev else None
+        self.next_num = page + 1 if self.has_next else None
+
+    def iter_pages(
+        self,
+        left_edge=2,
+        left_current=2,
+        right_current=4,
+        right_edge=2,
+    ):
+        last = 0
+        for num in range(1, self.pages + 1):
+            if (
+                num <= left_edge
+                or self.page - left_current < num < self.page + right_current
+                or num > self.pages - right_edge
+            ):
+                if last + 1 != num:
+                    yield None
+                yield num
+                last = num
+
+
+def _admin_page():
+    return max(request.args.get("page", 1, type=int) or 1, 1)
+
+
+def _paginate_query(query, per_page=ADMIN_LIST_PER_PAGE):
+    return query.paginate(page=_admin_page(), per_page=per_page, error_out=False)
+
+
+def _paginate_items(items, per_page=ADMIN_LIST_PER_PAGE):
+    page = _admin_page()
+    total = len(items)
+    start = (page - 1) * per_page
+    return ListPagination(items[start : start + per_page], page, per_page, total)
 
 
 def _list_filters():
@@ -320,9 +368,10 @@ def admin_dashboard():
         "posts": Post.query.count(),
         "comments": Comment.query.count(),
         "feedback_open": Feedback.query.filter_by(status="open").count(),
+        "merchant_pending": MerchantVerification.query.filter_by(status="pending").count(),
+        "logs": AdminLog.query.count(),
     }
-    logs = AdminLog.query.order_by(AdminLog.created_at.desc()).limit(30).all()
-    return render_template("admin_dashboard.html", stats=stats, logs=logs)
+    return render_template("admin_dashboard.html", stats=stats)
 
 
 @admin_bp.route("/admin/feedback")
@@ -357,7 +406,8 @@ def admin_feedback():
     else:
         query = query.order_by(status_rank, Feedback.created_at.desc(), Feedback.id.desc())
 
-    feedback_items = query.all()
+    pagination = _paginate_query(query)
+    feedback_items = pagination.items
     category_options = [
         row[0]
         for row in db.session.query(Feedback.category)
@@ -369,6 +419,9 @@ def admin_feedback():
     return render_template(
         "admin_feedback_list.html",
         feedback_items=feedback_items,
+        pagination=pagination,
+        page=pagination.page,
+        per_page=pagination.per_page,
         filters=filters,
         status_options=FEEDBACK_STATUSES,
         type_options=category_options,
@@ -460,7 +513,8 @@ def admin_logs():
         )
     if filters["type"]:
         query = query.filter(AdminLog.target_type == filters["type"])
-    logs = _apply_sort(query, AdminLog.created_at, AdminLog.id).limit(100).all()
+    pagination = _paginate_query(_apply_sort(query, AdminLog.created_at, AdminLog.id))
+    logs = pagination.items
     type_options = [
         row[0]
         for row in db.session.query(AdminLog.target_type)
@@ -469,7 +523,15 @@ def admin_logs():
         .all()
         if row[0]
     ]
-    return render_template("admin_logs.html", logs=logs, filters=filters, type_options=type_options)
+    return render_template(
+        "admin_logs.html",
+        logs=logs,
+        pagination=pagination,
+        page=pagination.page,
+        per_page=pagination.per_page,
+        filters=filters,
+        type_options=type_options,
+    )
 
 
 @admin_bp.route("/admin/users")
@@ -485,6 +547,8 @@ def admin_users():
     users = _apply_sort(query, User.created_at, User.id).all()
     if filters["q"]:
         users = [user for user in users if _admin_user_matches_search(user, filters["q"])]
+    pagination = _paginate_items(users)
+    users = pagination.items
     verified_merchant_user_ids = {
         row[0]
         for row in db.session.query(MerchantVerification.user_id)
@@ -495,6 +559,9 @@ def admin_users():
     return render_template(
         "admin_users.html",
         users=users,
+        pagination=pagination,
+        page=pagination.page,
+        per_page=pagination.per_page,
         ip_region_labels={user.id: _admin_user_ip_region_label(user) for user in users},
         masked_ip_addresses={user.id: _mask_ip_address(user.last_ip) for user in users},
         verified_merchant_user_ids=verified_merchant_user_ids,
@@ -727,10 +794,14 @@ def admin_activities():
         )
     if filters["status"]:
         query = query.filter(Activity.status == filters["status"])
-    activities = _apply_sort(query, Activity.created_at, Activity.id).all()
+    pagination = _paginate_query(_apply_sort(query, Activity.created_at, Activity.id))
+    activities = pagination.items
     return render_template(
         "admin_activities.html",
         activities=activities,
+        pagination=pagination,
+        page=pagination.page,
+        per_page=pagination.per_page,
         filters=filters,
         status_options=sorted(ACTIVITY_STATUSES),
     )
@@ -822,10 +893,14 @@ def admin_circles():
     elif filters["type"] == "custom":
         circles = circles.filter(Circle.is_system.is_(False))
     circles = circles.group_by(Circle.id)
-    circles = _apply_sort(circles, Circle.created_at, Circle.id).all()
+    pagination = _paginate_query(_apply_sort(circles, Circle.created_at, Circle.id))
+    circles = pagination.items
     return render_template(
         "admin_circles.html",
         circles=circles,
+        pagination=pagination,
+        page=pagination.page,
+        per_page=pagination.per_page,
         filters=filters,
         status_options=sorted(CIRCLE_STATUSES),
         type_options=["official", "custom"],
@@ -926,7 +1001,8 @@ def admin_posts():
         query = query.filter(Post.status == filters["status"])
     if filters["type"]:
         query = query.filter(Post.type == filters["type"])
-    posts = _apply_sort(query, Post.created_at, Post.id).all()
+    pagination = _paginate_query(_apply_sort(query, Post.created_at, Post.id))
+    posts = pagination.items
     type_options = [
         row[0]
         for row in db.session.query(Post.type).distinct().order_by(Post.type).all()
@@ -935,6 +1011,9 @@ def admin_posts():
     return render_template(
         "admin_posts.html",
         posts=posts,
+        pagination=pagination,
+        page=pagination.page,
+        per_page=pagination.per_page,
         filters=filters,
         status_options=sorted(CONTENT_STATUSES | {"deleted"}),
         type_options=type_options,
@@ -1113,10 +1192,14 @@ def admin_comments():
         query = query.filter(Comment.post_id.isnot(None), Comment.parent_id.is_(None))
     elif filters["type"] == "activity":
         query = query.filter(Comment.activity_id.isnot(None), Comment.parent_id.is_(None))
-    comments = _apply_sort(query, Comment.created_at, Comment.id).all()
+    pagination = _paginate_query(_apply_sort(query, Comment.created_at, Comment.id))
+    comments = pagination.items
     return render_template(
         "admin_comments.html",
         comments=comments,
+        pagination=pagination,
+        page=pagination.page,
+        per_page=pagination.per_page,
         filters=filters,
         status_options=sorted(CONTENT_STATUSES | {"deleted"}),
         type_options=["post", "activity", "reply"],
@@ -1261,12 +1344,20 @@ def admin_account():
 @admin_bp.route("/admin/merchant-verifications")
 @admin_required
 def merchant_verifications():
-    applications = (
-        MerchantVerification.query.join(MerchantVerification.user)
-        .order_by(MerchantVerification.created_at.desc(), MerchantVerification.id.desc())
-        .all()
+    pagination = _paginate_query(
+        MerchantVerification.query.join(MerchantVerification.user).order_by(
+            MerchantVerification.created_at.desc(),
+            MerchantVerification.id.desc(),
+        )
     )
-    return render_template("admin_merchant_verifications.html", applications=applications)
+    applications = pagination.items
+    return render_template(
+        "admin_merchant_verifications.html",
+        applications=applications,
+        pagination=pagination,
+        page=pagination.page,
+        per_page=pagination.per_page,
+    )
 
 
 @admin_bp.route("/admin/merchant-verifications/<int:verification_id>/review", methods=["POST"])

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2414,11 +2414,19 @@ textarea.form-input {
 }
 
 .admin-card {
+  display: flex;
+  min-height: 154px;
+  height: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 10px;
   padding: 24px;
   border: 1px solid var(--color-border);
-  border-radius: 12px;
+  border-radius: 10px;
   background: var(--color-surface);
   box-shadow: 0 8px 20px rgba(34, 34, 34, 0.05);
+  color: inherit;
+  text-decoration: none;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
@@ -2429,19 +2437,22 @@ textarea.form-input {
 }
 
 .admin-card h2 {
-  margin-bottom: 8px;
+  margin-bottom: 0;
   color: var(--color-primary-dark);
   font-size: 20px;
+  line-height: 1.25;
 }
 
 .admin-card p {
   margin-bottom: 0;
   color: var(--color-muted);
+  line-height: 1.5;
 }
 
 .admin-card strong {
   display: block;
-  margin-bottom: 6px;
+  margin-top: auto;
+  margin-bottom: 0;
   color: var(--color-primary);
   font-size: 34px;
   line-height: 1;
@@ -2578,6 +2589,92 @@ textarea.form-input {
   text-align: center !important;
 }
 
+.admin-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.admin-pagination-summary {
+  flex: 1 1 180px;
+}
+
+.admin-pagination-pages {
+  display: flex;
+  flex: 1 1 auto;
+  justify-content: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.admin-pagination-link,
+.admin-pagination-ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  min-height: 36px;
+  padding: 0 11px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.admin-pagination-link:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary-dark);
+}
+
+.admin-pagination-link.is-active {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.admin-pagination-link.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.admin-pagination-link.is-disabled:hover {
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.admin-pagination-ellipsis {
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-muted);
+}
+
+@media (max-width: 640px) {
+  .admin-pagination {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .admin-pagination-pages {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .admin-pagination-link,
+  .admin-pagination-ellipsis {
+    min-width: 34px;
+    min-height: 34px;
+    padding: 0 10px;
+  }
+}
+
 .admin-status {
   display: inline-flex;
   padding: 2px 8px;
@@ -2677,6 +2774,12 @@ textarea.form-input {
   background: #f8e8e4;
   color: #8b4638;
   font-weight: 700;
+}
+
+@media (max-width: 1024px) {
+  .admin-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .profile-page {

--- a/app/templates/_pagination.html
+++ b/app/templates/_pagination.html
@@ -1,0 +1,50 @@
+{% macro pagination_link(page_num, label, classes='', aria_label='') %}
+  {% set args = request.args.to_dict() %}
+  {% set _ = args.update({'page': page_num}) %}
+  <a class="admin-pagination-link {{ classes }}" href="{{ url_for(request.endpoint, **args) }}"{% if aria_label %} aria-label="{{ aria_label }}"{% endif %}>{{ label }}</a>
+{% endmacro %}
+
+{% macro pagination_nav(pagination) %}
+  {% if pagination %}
+  <nav class="admin-pagination" aria-label="分页导航">
+    <div class="admin-pagination-summary">
+      {% if pagination.total == 0 %}
+        共 0 条
+      {% elif pagination.items %}
+        {% set first_item = (pagination.page - 1) * pagination.per_page + 1 %}
+        {% set last_item = first_item + pagination.items|length - 1 %}
+        显示 {{ first_item }}-{{ last_item }} 条，共 {{ pagination.total }} 条
+      {% else %}
+        共 {{ pagination.total }} 条
+      {% endif %}
+    </div>
+    {% if pagination.pages > 1 %}
+    <div class="admin-pagination-pages">
+      {% if pagination.has_prev %}
+        {{ pagination_link(pagination.prev_num, '上一页', 'admin-pagination-prev', '上一页') }}
+      {% else %}
+        <span class="admin-pagination-link admin-pagination-prev is-disabled" aria-disabled="true">上一页</span>
+      {% endif %}
+
+      {% for page_num in pagination.iter_pages(left_edge=1, left_current=2, right_current=2, right_edge=1) %}
+        {% if page_num %}
+          {% if page_num == pagination.page %}
+            <span class="admin-pagination-link is-active" aria-current="page">{{ page_num }}</span>
+          {% else %}
+            {{ pagination_link(page_num, page_num) }}
+          {% endif %}
+        {% else %}
+          <span class="admin-pagination-ellipsis" aria-hidden="true">...</span>
+        {% endif %}
+      {% endfor %}
+
+      {% if pagination.has_next %}
+        {{ pagination_link(pagination.next_num, '下一页', 'admin-pagination-next', '下一页') }}
+      {% else %}
+        <span class="admin-pagination-link admin-pagination-next is-disabled" aria-disabled="true">下一页</span>
+      {% endif %}
+    </div>
+    {% endif %}
+  </nav>
+  {% endif %}
+{% endmacro %}

--- a/app/templates/admin_account.html
+++ b/app/templates/admin_account.html
@@ -14,7 +14,7 @@
       <a href="{{ url_for('admin.admin_posts') }}">帖子</a>
       <a href="{{ url_for('admin.admin_comments') }}">评论</a>
       <a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a>
-      <a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+      <a href="{{ url_for('admin.admin_logs') }}">操作日志</a>
     </nav>
     <div class="page-title">
       <p class="eyebrow">Admin Account</p>

--- a/app/templates/admin_activities.html
+++ b/app/templates/admin_activities.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% from "_list_filters.html" import list_filters %}
+{% from "_pagination.html" import pagination_nav %}
 {% block title %}活动管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
   <nav class="admin-nav" aria-label="后台管理导航">
-    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a class="is-active" href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a class="is-active" href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_logs') }}">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Activities</p><h1>活动管理</h1><p>查看活动、维护状态，并指定首页近期推荐的精选活动。</p></div>
   {{ list_filters('admin.admin_activities', filters, status_options) }}
@@ -34,5 +35,6 @@
       </td>
     </tr>{% else %}<tr><td class="admin-empty" colspan="9">暂无活动。</td></tr>{% endfor %}</tbody>
   </table></div>
+  {{ pagination_nav(pagination) }}
 </div></section>
 {% endblock %}

--- a/app/templates/admin_circles.html
+++ b/app/templates/admin_circles.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% from "_list_filters.html" import list_filters %}
+{% from "_pagination.html" import pagination_nav %}
 {% block title %}同好圈管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
   <nav class="admin-nav" aria-label="后台管理导航">
-    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a class="is-active" href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a class="is-active" href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_logs') }}">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Circles</p><h1>同好圈管理</h1><p>查看全部同好圈，并隐藏、恢复显示或删除内容。</p></div>
   {{ list_filters('admin.admin_circles', filters, status_options, type_options) }}
@@ -34,5 +35,6 @@
       </div></td>
     </tr>{% else %}<tr><td class="admin-empty" colspan="8">暂无同好圈。</td></tr>{% endfor %}</tbody>
   </table></div>
+  {{ pagination_nav(pagination) }}
 </div></section>
 {% endblock %}

--- a/app/templates/admin_comments.html
+++ b/app/templates/admin_comments.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% from "_list_filters.html" import list_filters %}
+{% from "_pagination.html" import pagination_nav %}
 {% block title %}评论管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
   <nav class="admin-nav" aria-label="后台管理导航">
-    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a class="is-active" href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a class="is-active" href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_logs') }}">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Comments</p><h1>评论管理</h1><p>查看用户发布的评论和回复，并删除违规或不适当的内容。</p></div>
   {{ list_filters('admin.admin_comments', filters, status_options, type_options) }}
@@ -31,5 +32,6 @@
       </div></td>
     </tr>{% else %}<tr><td class="admin-empty" colspan="7">暂无评论。</td></tr>{% endfor %}</tbody>
   </table></div>
+  {{ pagination_nav(pagination) }}
 </div></section>
 {% endblock %}

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -14,6 +14,7 @@
       <a href="{{ url_for('admin.admin_posts') }}">帖子</a>
       <a href="{{ url_for('admin.admin_comments') }}">评论</a>
       <a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a>
+      <a href="{{ url_for('admin.merchant_verifications') }}">商家认证</a>
       <a href="{{ url_for('admin.admin_logs') }}">操作日志</a>
     </nav>
 
@@ -24,43 +25,47 @@
     </div>
 
     <div class="admin-grid" aria-label="后台管理模块">
-      <a class="admin-card" href="{{ url_for('admin.admin_users') }}"><h2>用户</h2><strong>{{ stats.users }}</strong><p>查看账号并维护用户状态。</p></a>
-      <a class="admin-card" href="{{ url_for('admin.admin_activities') }}"><h2>活动</h2><strong>{{ stats.activities }}</strong><p>维护活动公开状态。</p></a>
-      <a class="admin-card" href="{{ url_for('admin.admin_circles') }}"><h2>同好圈</h2><strong>{{ stats.circles }}</strong><p>查看、隐藏或删除同好圈。</p></a>
-      <a class="admin-card" href="{{ url_for('admin.admin_posts') }}"><h2>帖子</h2><strong>{{ stats.posts }}</strong><p>查看、隐藏或删除用户帖子。</p></a>
-      <a class="admin-card" href="{{ url_for('admin.admin_comments') }}"><h2>评论</h2><strong>{{ stats.comments }}</strong><p>查看、隐藏或删除评论和回复。</p></a>
-      <a class="admin-card" href="{{ url_for('admin.admin_feedback') }}"><h2>问题反馈</h2><strong>{{ stats.feedback_open }}</strong><p>查看、回复或关闭用户反馈。</p></a>
-      <a class="admin-card" href="{{ url_for('admin.admin_account') }}"><h2>账号设置</h2><p>修改管理员账号信息和密码。</p></a>
-      <a class="admin-card" href="{{ url_for('admin.admin_logs') }}"><h2>操作日志</h2><p>查看最近管理员操作记录。</p></a>
+      <a class="admin-card" href="{{ url_for('admin.admin_users') }}">
+        <h2>用户</h2>
+        <strong>{{ stats.users }}</strong>
+        <p>查看账号并维护用户状态。</p>
+      </a>
+      <a class="admin-card" href="{{ url_for('admin.admin_activities') }}">
+        <h2>活动</h2>
+        <strong>{{ stats.activities }}</strong>
+        <p>维护活动公开状态。</p>
+      </a>
+      <a class="admin-card" href="{{ url_for('admin.admin_circles') }}">
+        <h2>同好圈</h2>
+        <strong>{{ stats.circles }}</strong>
+        <p>查看、隐藏或删除同好圈。</p>
+      </a>
+      <a class="admin-card" href="{{ url_for('admin.admin_posts') }}">
+        <h2>帖子</h2>
+        <strong>{{ stats.posts }}</strong>
+        <p>查看、隐藏或删除用户帖子。</p>
+      </a>
+      <a class="admin-card" href="{{ url_for('admin.admin_comments') }}">
+        <h2>评论</h2>
+        <strong>{{ stats.comments }}</strong>
+        <p>查看、隐藏或删除评论和回复。</p>
+      </a>
+      <a class="admin-card" href="{{ url_for('admin.admin_feedback') }}">
+        <h2>问题反馈</h2>
+        <strong>{{ stats.feedback_open }}</strong>
+        <p>查看、回复或关闭用户反馈。</p>
+      </a>
+      <a class="admin-card" href="{{ url_for('admin.merchant_verifications') }}">
+        <h2>商家认证审核</h2>
+        <strong>{{ stats.merchant_pending }}</strong>
+        <p>审核商家认证申请并通知用户。</p>
+      </a>
+      <a class="admin-card" href="{{ url_for('admin.admin_logs') }}">
+        <h2>操作日志</h2>
+        <strong>{{ stats.logs }}</strong>
+        <p>查看管理员操作记录。</p>
+      </a>
     </div>
-
-    <p><a class="button" href="{{ url_for('admin.merchant_verifications') }}">审核商家认证申请</a></p>
-
-    <section class="admin-panel" id="operation-logs">
-      <div class="admin-panel-heading">
-        <div><p class="eyebrow">Audit Trail</p><h2>操作日志</h2></div>
-        <p><a href="{{ url_for('admin.admin_logs') }}">查看最近 100 条记录</a></p>
-      </div>
-      <div class="admin-table-wrap">
-        <table class="admin-table">
-          <thead><tr><th>时间</th><th>管理员</th><th>操作</th><th>对象</th><th>详情</th><th>IP</th></tr></thead>
-          <tbody>
-            {% for log in logs %}
-              <tr>
-                <td>{{ log.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
-                <td>{{ log.admin.username }}</td>
-                <td>{{ log.action }}</td>
-                <td>{{ log.target_type }}{% if log.target_id %} #{{ log.target_id }}{% endif %}</td>
-                <td>{{ log.detail or '-' }}</td>
-                <td>{{ log.ip_address or '-' }}</td>
-              </tr>
-            {% else %}
-              <tr><td class="admin-empty" colspan="6">暂无后台操作日志。</td></tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </section>
   </div>
 </section>
 {% endblock %}

--- a/app/templates/admin_feedback_list.html
+++ b/app/templates/admin_feedback_list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "_list_filters.html" import list_filters %}
+{% from "_pagination.html" import pagination_nav %}
 
 {% block title %}问题反馈管理 - Gatherly{% endblock %}
 
@@ -55,6 +56,7 @@
         </tbody>
       </table>
     </div>
+    {{ pagination_nav(pagination) }}
   </div>
 </section>
 {% endblock %}

--- a/app/templates/admin_logs.html
+++ b/app/templates/admin_logs.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "_list_filters.html" import list_filters %}
+{% from "_pagination.html" import pagination_nav %}
 
 {% block title %}操作日志 - Gatherly{% endblock %}
 
@@ -21,7 +22,7 @@
     <div class="page-title">
       <p class="eyebrow">Audit Trail</p>
       <h1>操作日志</h1>
-      <p>查看最近 100 条管理员操作记录。</p>
+      <p>分页查看管理员操作记录。</p>
     </div>
 
     {{ list_filters('admin.admin_logs', filters, (), type_options) }}
@@ -44,6 +45,7 @@
         </tbody>
       </table>
     </div>
+    {{ pagination_nav(pagination) }}
   </div>
 </section>
 {% endblock %}

--- a/app/templates/admin_merchant_verifications.html
+++ b/app/templates/admin_merchant_verifications.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_pagination.html" import pagination_nav %}
 
 {% block title %}商家认证审核 - Gatherly{% endblock %}
 
@@ -57,6 +58,7 @@
         </tbody>
       </table>
     </div>
+    {{ pagination_nav(pagination) }}
   </div>
 </section>
 {% endblock %}

--- a/app/templates/admin_posts.html
+++ b/app/templates/admin_posts.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% from "_list_filters.html" import list_filters %}
+{% from "_pagination.html" import pagination_nav %}
 {% block title %}帖子管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
   <nav class="admin-nav" aria-label="后台管理导航">
-    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a class="is-active" href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a class="is-active" href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_logs') }}">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Posts</p><h1>帖子管理</h1><p>查看用户发布的帖子，并删除违规或不适当的内容。</p></div>
   {{ list_filters('admin.admin_posts', filters, status_options, type_options) }}
@@ -27,5 +28,6 @@
       </div></td>
     </tr>{% else %}<tr><td class="admin-empty" colspan="7">暂无帖子。</td></tr>{% endfor %}</tbody>
   </table></div>
+  {{ pagination_nav(pagination) }}
 </div></section>
 {% endblock %}

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% from "_list_filters.html" import list_filters %}
+{% from "_pagination.html" import pagination_nav %}
 {% block title %}用户管理 - Gatherly{% endblock %}
 {% block content %}
 <section class="section"><div class="container">
   <nav class="admin-nav" aria-label="后台管理导航">
-    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a class="is-active" href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_dashboard') }}#operation-logs">操作日志</a>
+    <a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a><a href="{{ url_for('admin.admin_account') }}">账号设置</a><a class="is-active" href="{{ url_for('admin.admin_users') }}">用户</a><a href="{{ url_for('admin.admin_activities') }}">活动</a><a href="{{ url_for('admin.admin_circles') }}">同好圈</a><a href="{{ url_for('admin.admin_posts') }}">帖子</a><a href="{{ url_for('admin.admin_comments') }}">评论</a><a href="{{ url_for('admin.admin_feedback') }}">问题反馈</a><a href="{{ url_for('admin.admin_logs') }}">操作日志</a>
   </nav>
   <div class="page-title"><p class="eyebrow">Admin Users</p><h1>用户管理</h1><p>查看平台用户并维护账号状态、管理员权限和商家资质。</p></div>
   {{ list_filters('admin.admin_users', filters, status_options, type_options, search_placeholder='搜索用户名、邮箱、地区、IP') }}
@@ -47,5 +48,6 @@
       </td>
     </tr>{% else %}<tr><td class="admin-empty" colspan="10">暂无用户。</td></tr>{% endfor %}</tbody>
   </table></div>
+  {{ pagination_nav(pagination) }}
 </div></section>
 {% endblock %}


### PR DESCRIPTION
## 追加优化内容
- 删除后台 Dashboard 首页中的“账号设置”卡片
- 保留账号设置相关路由和功能，不影响后台其他入口
- 后台首页卡片网格自动重新排列，避免空白卡位

## 追加自测
- [x] 后台首页不再显示账号设置卡片
- [x] 其他后台卡片正常显示
- [x] 其他后台卡片跳转正常
- [x] python -m compileall app 通过
- [x] git diff --check 通过

## 数据库说明
- 未修改 app/models.py
- 未新增数据库字段
- 未新增 migration
- 不需要执行 flask db upgrade